### PR TITLE
fix(dual): correct pane indices and codex launch command

### DIFF
--- a/dev
+++ b/dev
@@ -413,7 +413,7 @@ _ai_launch_cmd() {
   case "$ai" in
     claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions" ;;
     kimi)   echo "'$KIMI_BIN'" ;;
-    codex)  echo "codex exec" ;;
+    codex)  echo "codex" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "gemini" ;;
     *)      return 1 ;;
@@ -790,11 +790,11 @@ _start_dual() {
   # Split right + launch RIGHT AI
   tmux split-window -h -t "$ORCH_SESSION:$name" -c "$dir"
   sleep 0.3
-  tmux send-keys -t "$ORCH_SESSION:$name.2" "$right_cmd" Enter
+  tmux send-keys -t "$ORCH_SESSION:$name.1" "$right_cmd" Enter
   sleep 2
 
   # Select left pane as active
-  tmux select-pane -t "$ORCH_SESSION:$name.1"
+  tmux select-pane -t "$ORCH_SESSION:$name.0"
 
   local win_index=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_index}:#{window_name}" 2>/dev/null | grep ":${name}$" | cut -d: -f1)
   _track_ai_type "$name" "dual:${left_ai}:${right_ai}"
@@ -913,15 +913,15 @@ _send() {
   fi
 
   # Determine target pane
-  local pane_target="$ORCH_SESSION:$name.1"
+  local pane_target="$ORCH_SESSION:$name.0"
   if [[ "$target" == "right" ]]; then
-    pane_target="$ORCH_SESSION:$name.2"
+    pane_target="$ORCH_SESSION:$name.1"
   fi
 
   # Detect which AI is actually running in the target pane (for logging).
-  # Pane indices: 1 = left, 2 = right (after split-window -h).
-  local pane_idx=1
-  [[ "$target" == "right" ]] && pane_idx=2
+  # Pane indices: 0 = left, 1 = right (after split-window -h, pane-base-index=0).
+  local pane_idx=0
+  [[ "$target" == "right" ]] && pane_idx=1
   local ai_label=$(_detect_pane_ai "$name" "$pane_idx")
   [[ -z "$ai_label" ]] && ai_label="unknown"
   local ai_type="$ai_label"
@@ -1049,8 +1049,8 @@ _peek() {
     return 1
   fi
 
-  local pane_target="$ORCH_SESSION:$name.1"
-  [[ "$target" == "right" ]] && pane_target="$ORCH_SESSION:$name.2"
+  local pane_target="$ORCH_SESSION:$name.0"
+  [[ "$target" == "right" ]] && pane_target="$ORCH_SESSION:$name.1"
 
   _log_history "PEEK $name [$target]"
 


### PR DESCRIPTION
## Summary

- **`codex exec` → `codex`**: `exec` is a non-interactive subcommand that exits immediately, leaving the right pane as a bare `zsh` shell. The interactive TUI is launched with plain `codex`.
- **Off-by-one pane targeting fixed** in `_start_dual`, `_send`, and `_peek`: tmux `pane-base-index` defaults to `0`, so after `split-window -h` the panes are `.0` (left) and `.1` (right) — not `.1`/`.2` as the code assumed. This caused every `dev send --right` and `dev peek --right` to fail with `can't find pane: 2`.

## Affected functions

| Function | Before | After |
|---|---|---|
| `_ai_launch_cmd` (codex) | `codex exec` | `codex` |
| `_start_dual` — launch right | `.2` | `.1` |
| `_start_dual` — select left | `.1` | `.0` |
| `_send` — left target | `.1` | `.0` |
| `_send` — right target | `.2` | `.1` |
| `_send` — pane_idx left/right | `1`/`2` | `0`/`1` |
| `_peek` — left target | `.1` | `.0` |
| `_peek` — right target | `.2` | `.1` |

## Test plan

- [ ] `dev start <alias> --dual claude codex` — both panes launch their respective AIs
- [ ] `dev send <alias> --right "msg"` — message reaches Codex
- [ ] `dev peek <alias> --right` — reads Codex output
- [ ] `dev send <alias> "msg"` — still reaches Claude (left pane unaffected)
- [ ] `dev peek <alias>` — still reads Claude output

Verified locally: `dev send --right` + `dev peek --right` round-trip confirmed with `TEST OK` response from Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)