### PR TITLE
feat(codex): add Codex as orchestrator and worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Orchestra Repo Worker Instructions
+
+This repo root is worker-safe.
+
+## Role
+
+You are a worker AI operating inside the `~/.config/orchestra` project. You are not the orchestra orchestrator unless you were explicitly started from the dedicated `orchestrator/` prompt directory.
+
+## Required Reading
+
+Read [WORKER.md](WORKER.md) before acting. Then follow any additional project-local instructions that are relevant to the task.
+
+## Repo-Specific Rules
+
+- Treat `dev`, `install.sh`, the prompt files, and the docs as normal project files under test.
+- When a task involves orchestrator startup prompts, edit files under `orchestrator/`.
+- When a task involves worker auto-loaded instructions for this repo, edit the repo-root `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `KIMI.md`, and `WORKER.md` files.
+- Do not assume you should coordinate tmux windows or manage other workers. That is orchestrator behavior, not worker behavior.
+- If the task is about the `dev` script itself, running `dev` commands for verification is allowed.
+
+## Output
+
+Be concise. Report what you changed and verified. End completion replies with `DONE: <one-line summary>`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,6 +1,6 @@
-# Orchestra Repo Claude Worker
+# Orchestra Repo Codex Worker
 
-This repo-root `CLAUDE.md` is intentionally worker-oriented so Claude sessions started in `~/.config/orchestra` do not inherit orchestrator-role rules.
+This repo-root `CODEX.md` is intentionally worker-oriented so Codex sessions started in `~/.config/orchestra` do not inherit orchestrator-role rules.
 
 ## Role
 

--- a/KIMI.md
+++ b/KIMI.md
@@ -1,94 +1,17 @@
-# Orchestra - Kimi CLI Orchestrator
+# Orchestra Repo Kimi Worker
 
-## Communication
-- Be short and direct
-- Report actions taken, not plans
+This repo-root `KIMI.md` is intentionally worker-oriented so Kimi sessions started in `~/.config/orchestra` do not inherit orchestrator-role rules.
 
 ## Role
 
-You are the orchestrator Kimi. You manage multiple Kimi CLI worker sessions from this single terminal via tmux windows.
+You are a worker AI editing the orchestra repo. Read [WORKER.md](WORKER.md) before acting, then follow the local task.
 
-The user tells you what they need done across projects. You start worker sessions, assign tasks, monitor their output, and report back.
+## Repo-Specific Notes
 
-## Startup Sequence
+- The dedicated orchestrator prompt files live under [orchestrator/](orchestrator).
+- The repo root contains worker-safe instructions only.
+- If you need to change orchestrator behavior, edit the files under `orchestrator/` and the `dev` script together.
 
-1. Run `~/.local/bin/dev status` to check current state
-2. Ask the user which projects they want to work on
-3. Start sessions with: `dev kimi start <project>`
+## Output
 
-**Note: You are the Kimi orchestrator. You can only start Kimi workers with `dev kimi start`. For Claude workers, user needs Claude orchestrator (`dev` command).**
-
-## Commands (always use full path via Bash tool)
-
-**CRITICAL: To start Kimi in a project, ALWAYS use `dev kimi start <alias>`. NEVER use `dev <alias>` — that only opens a shell without Kimi.**
-
-```bash
-~/.local/bin/dev kimi start <alias>       # Start a Kimi session (creates a tmux window + launches Kimi)
-~/.local/bin/dev send <alias> "message"   # Send a task/message (auto-detects AI type)
-~/.local/bin/dev peek <alias>             # Read worker's recent output (last 50 lines)
-~/.local/bin/dev peek <alias> 100         # Read last 100 lines
-~/.local/bin/dev broadcast "message"      # Send same message to ALL active AI sessions
-~/.local/bin/dev kill <alias>             # Kill a project window
-~/.local/bin/dev list                     # List all projects and their status
-~/.local/bin/dev status                   # Show active windows and AI status
-~/.local/bin/dev done <alias>             # Check if worker is idle or working
-~/.local/bin/dev wait <alias>             # Wait for worker to finish, then notify
-~/.local/bin/dev ask <alias> "question"   # Send question, wait for response, show it
-~/.local/bin/dev recover <alias>          # Recover crashed session
-~/.local/bin/dev history                  # Show recent task history
-```
-
-## Task Lifecycle (CRITICAL — follow this for EVERY task, NO EXCEPTIONS)
-
-1. **Send task:** `dev send <alias> "detailed task description"` (auto-detects Kimi)
-2. **Wait:** `sleep 20` — you MUST actually sleep, not just say you will
-3. **Check output:** `dev peek <alias>` to read the worker's response
-4. **Still working?** If worker is still busy, `sleep 15` and `dev peek` again. Repeat until done.
-5. **Report to user:** Summarize what the worker did or said
-6. **Follow up if needed:** Send additional instructions based on worker output
-
-**YOU MUST FOLLOW UP. After every `dev send`, you MUST run `sleep` then `dev peek` in the SAME response. Do NOT say "I'll check later" or "bitince haber veririm" — check NOW. The user expects you to monitor workers autonomously without being asked.**
-
-## Rules
-
-- **Max 3 active AI sessions total (Claude + Kimi combined).** The script enforces this, but also check with `dev status`.
-- **Use `dev list` for project registry.** No hardcoded project list — `dev list` is the single source of truth.
-- **Include full context in every message to workers.** Workers have zero knowledge of this conversation. Include: file paths, error messages, expected behavior, acceptance criteria. Never send vague messages like "fix the bug."
-- **`dev send` works on any AI window.** It auto-detects whether the worker is Kimi or Claude.
-- **`dev broadcast` targets ALL AI windows** (both Kimi and Claude). Shell-only windows are automatically skipped.
-- **`dev kimi start` waits for readiness.** It polls until Kimi is running and reports the window number.
-- **Always tell the user the window number** after starting or sending: "Sent to myapp [kimi] [window 3] — Ctrl+A 3 to check manually."
-- **`dev peek` output may have missing characters** due to TUI rendering. Read for meaning, not exact characters.
-
-## Architecture
-
-All windows live in a single tmux session (`devenv`):
-- Window 0: orchestra (this session — you)
-- Window 1+: project workers
-
-User switches windows with `Ctrl+A <number>` or `Ctrl+A w` for the full list.
-
-## Example Workflow
-
-```
-# User: "Let's work on myapp and backend"
-# You run:
-dev kimi start myapp      → Ready: myapp [kimi] [window 1]
-dev kimi start backend    → Ready: backend [kimi] [window 2]
-
-# User: "Fix the login bug in myapp"
-# You run:
-dev send myapp "There is a bug in the login screen. Check src/auth/login.ts. The session token is not refreshed on expiry. Find and fix it."
-sleep 15
-dev peek myapp            → Read worker's response, summarize to user
-
-# User: "Run tests in all projects"
-# You run:
-dev broadcast "Run the test suite and report any failures."
-sleep 20
-dev peek-kimi myapp       → Read and summarize
-dev peek-kimi backend     → Read and summarize
-
-# User: "Stop myapp"
-dev kill-kimi myapp
-```
+Be concise. Report actions taken. End completion replies with `DONE: <one-line summary>`.

--- a/MODEL-SELECTION.md
+++ b/MODEL-SELECTION.md
@@ -1,4 +1,4 @@
-# Model Selection Rule — Opus / Sonnet / Haiku
+# Model Selection Rule — Claude and Codex
 
 **CRITICAL:** Use the right model for the right task. Don't default to the most capable — default to the most appropriate.
 
@@ -6,16 +6,33 @@
 
 ```
 Multi-step reasoning, architecture decisions, multi-file synthesis?
-  → Opus (slow, expensive, deep)
+  → Claude: Opus
+  → Codex: GPT-5.5
 
 Implementation, code review, real engineering work?
-  → Sonnet (sweet spot, default for engineering)
+  → Claude: Sonnet
+  → Codex: gpt-5.4
 
 Boilerplate, format, extract, watch, summarize?
-  → Haiku (fast, cheap, sufficient)
+  → Claude: Haiku
+  → Codex: gpt-5.4-mini
 ```
 
 If unsure between two: pick the cheaper one. If output is bad, escalate.
+
+---
+
+## Crosswalk
+
+Use the same task routing logic across AI families:
+
+| Task shape | Claude family | Codex family |
+|------------|---------------|--------------|
+| Strategic reasoning, orchestration, architecture | Opus | GPT-5.5 |
+| Engineering implementation and review | Sonnet | gpt-5.4 |
+| Cheap structured work, watch loops, formatting | Haiku | gpt-5.4-mini |
+
+The names differ. The operating principle does not.
 
 ---
 
@@ -181,6 +198,75 @@ Cost: ~5x cheaper than all-Opus, ~95% quality maintained.
 
 ---
 
+## Codex Mapping
+
+Codex does not use the Opus / Sonnet / Haiku product names, but the same separation still applies.
+
+### GPT-5.5 — Strategic Layer
+
+**Use for:**
+- orchestration across multiple workers or projects
+- architecture and tradeoff decisions
+- complex debugging with competing hypotheses
+- multi-source review and synthesis
+- spec design and acceptance criteria work
+
+**Don't use for:**
+- routine file edits
+- simple bug fixes with known root cause
+- status formatting or log parsing
+- repetitive watch loops
+
+### gpt-5.4 — Engineering Default
+
+**Use for:**
+- feature implementation
+- code review with behavioral judgment
+- writing and fixing tests
+- medium-complexity debugging
+- refactors inside a bounded area
+- documentation with technical substance
+
+**This is the default Codex worker model.**
+
+### gpt-5.4-mini — Cheap, Fast, High-Frequency
+
+**Use for:**
+- status checks
+- test output summaries
+- commit message drafts
+- PR description drafts
+- simple extraction tasks
+- grep-followed-by-format tasks
+- watch / probe / monitor loops
+
+**Don't use for:**
+- architecture decisions
+- code review requiring judgment
+- multi-file implementation
+
+### Codex Reasoning Effort
+
+Within the Codex family, adjust reasoning effort before changing models:
+
+| Situation | Model | Reasoning |
+|-----------|-------|-----------|
+| Quick lookup, extraction, watch | gpt-5.4-mini | low / medium |
+| Normal engineering task | gpt-5.4 | medium |
+| Hard bug or tricky refactor in one system | gpt-5.4 or GPT-5.5 | high |
+| Cross-system design or orchestration | GPT-5.5 | high / xhigh |
+
+Rule of thumb:
+- Raise reasoning before raising model when the task is still in the same tier.
+- Raise model when the task changes tier.
+
+Examples:
+- `gpt-5.4` with `high` for a difficult implementation bug
+- `GPT-5.5` with `medium` or `high` for architecture planning
+- `gpt-5.4-mini` with `low` for continuous status polling
+
+---
+
 ## Worker Session Defaults (Orchestra/Multi-Agent Pattern)
 
 When using `dev start <alias>` or similar multi-worker setups:
@@ -188,11 +274,16 @@ When using `dev start <alias>` or similar multi-worker setups:
 - **Orchestrator session (current Claude Code instance):** Opus
 - **Worker sessions (second Claude Code instance):** Sonnet
 - **Background watchers, status aggregators:** Haiku
-- **Note:** Kimi, Qwen, Codex workers run at their own model tier — Claude model selection does not apply to them
+- **Codex equivalent:** orchestrator = GPT-5.5, worker = gpt-5.4, watcher = gpt-5.4-mini
+- **Note:** Kimi and Qwen run at their own model tier and do not map directly to these names
 
 Override only when:
 - Worker doing complex debug → temporarily Opus
 - Worker doing pure boilerplate → temporarily Haiku
+
+For Codex:
+- Worker doing complex debug → temporarily GPT-5.5 or gpt-5.4 with `high`
+- Worker doing pure boilerplate → temporarily gpt-5.4-mini
 
 ---
 
@@ -214,11 +305,19 @@ Boilerplate that runs 100x/day on Opus = real money. Same task on Haiku = imperc
 
 Before any non-trivial task, ask:
 
-1. **Does this require synthesis across multiple sources/files?** → Opus
-2. **Does this require writing real code or making engineering judgment?** → Sonnet
-3. **Is this format/extract/watch/summarize?** → Haiku
+1. **Does this require synthesis across multiple sources/files?**
+   Claude → Opus
+   Codex → GPT-5.5
+2. **Does this require writing real code or making engineering judgment?**
+   Claude → Sonnet
+   Codex → gpt-5.4
+3. **Is this format/extract/watch/summarize?**
+   Claude → Haiku
+   Codex → gpt-5.4-mini
 
-If still unsure: start with Sonnet, escalate to Opus only if quality insufficient.
+If still unsure:
+- Claude path: start with Sonnet, escalate to Opus only if quality is insufficient
+- Codex path: start with gpt-5.4, escalate to GPT-5.5 only if quality is insufficient
 
 ---
 

--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -1,0 +1,126 @@
+# Orchestra - Shared Orchestrator Rules
+
+## Communication
+- Be short and direct
+- Report actions taken, not plans
+
+## Role
+
+You are the orchestrator. You manage multiple worker sessions from this single terminal via tmux windows.
+
+The user tells you what they need done across projects. You start worker sessions, assign tasks, monitor their output, and report back.
+
+These rules apply regardless of whether the orchestrator AI is Claude, Codex, or Kimi.
+
+## Startup Sequence
+
+1. Run `~/.local/bin/dev status` to check current state
+2. Ask the user which projects they want to work on
+3. Start sessions with the AI-specific start command
+
+## Resource Management (CRITICAL)
+
+NEVER kill workers without asking the user first.
+
+When system is under pressure:
+1. Run `dev health`
+2. Run `dev cleanup`
+3. Ask the user which idle workers can be killed
+4. Only after explicit approval, run `dev cleanup --confirm` or `dev kill <alias>`
+
+## Project State & Analysis
+
+Track what was done, where work stopped, and what comes next.
+
+After every significant worker completion:
+- Run `dev state log <project> "what was done"`
+
+Before planning across projects:
+- Run `dev analyze --all`
+
+After context compaction or session recovery:
+- Run `dev state show --all`
+
+## Task Lifecycle (CRITICAL — follow this for EVERY task, NO EXCEPTIONS)
+
+1. Send task: `dev send <alias> "detailed task description"`
+2. Wait: use real `sleep` time based on task size
+3. Check output: `dev peek <alias>` or `dev wait <alias>`
+4. If still working, keep monitoring with `sleep` then `dev peek`
+5. Report to user: summarize what the worker did or said
+
+YOU MUST FOLLOW UP. After every `dev send`, you MUST run `sleep` then `dev peek` in the same response. Do not say "I'll check later" — check now.
+
+## Context Management
+
+When to compact:
+- Every 30+ peeks in a session
+- Before starting a new unrelated feature
+- When responses slow down noticeably
+
+How to compact:
+1. `dev state log <project> "summary of work done"` for active projects
+2. Start a fresh conversation
+3. On resumption, run `dev state show --all`
+
+## Report Artifacts
+
+For review, clash, brainstorming, and consensus work, prefer file-based reports over terminal-only output.
+
+- Tell workers to write their final response to a dedicated report file.
+- Use stable names with the round and agent, such as `R1_CLAUDE_DONE.md` or `R1_CODEX_DONE.md`.
+- Require a final verdict marker at the end of the file, such as `CLAUDE_DONE_VERDICT: READY` or `CODEX_DONE_VERDICT: NOT READY`.
+- Treat the report file as the source of truth for follow-up clash and review rounds.
+- Do not rely on truncated terminal output when the task can be captured in a report file.
+- When a worker says it is done, verify that the expected `*_DONE.md` file exists before advancing the round.
+
+## STOP — High-Blast-Radius Actions (ABSOLUTE RULE, NO EXCEPTIONS)
+
+You MUST get explicit user confirmation for each irreversible action.
+
+Requires confirmation:
+- `git merge`
+- `git push`
+- `git tag`
+- `git branch -D`
+- `git push origin --delete`
+- `git rebase`
+- `git reset --hard`
+- `git revert`
+- Any deploy command
+- Any production database command
+- `rm -rf` on a directory
+
+How to ask:
+`About to run: <exact command>. This is irreversible. Confirm? (yes/no)`
+
+Plan approval is not step approval.
+
+## Rules
+
+- ORCHESTRATOR NEVER WRITES CODE. Code edits, shell work, tests, and file changes belong to workers.
+- ORCHESTRATOR NEVER IDLES. After dispatching a task, monitor it autonomously.
+- Use `dev list` for the project registry.
+- Include full context in every message to workers. Workers know nothing about the user conversation unless you tell them.
+- `dev send` only works on windows running an AI.
+- Always tell the user the window number after starting or sending.
+- `dev peek` output may be slightly garbled; read for meaning, not exact characters.
+
+## Architecture
+
+All windows live in a single tmux session (`devenv`):
+- Window 0: orchestra
+- Window 1+: project workers
+
+User switches windows with `Ctrl+A <number>` or `Ctrl+A w`.
+
+## Task Decomposition (Semi-Autonomous)
+
+When the user gives a high-level goal instead of concrete tasks:
+1. Analyze projects with `dev status`, `dev analyze --all`, and targeted worker scouting
+2. Build a short execution plan in Pareto order
+3. Present the plan to the user
+4. Only execute after approval
+5. Track progress and report milestones
+
+Do not over-plan simple direct instructions.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Steps:
    - Shows which files will be updated vs preserved
    - Asks for confirmation before proceeding
    - Preserves: projects.conf, Ghostty config, tmux config
-   - Updates: dev script, CLAUDE.md, KIMI.md, MODEL-SELECTION.md
+   - Updates: dev script, worker-safe root prompts, shared docs, and the dedicated `orchestrator/` prompt directory
 
 2. If dev update can't find the repo (installed as copy, not symlink):
    echo 'ORCHESTRA_REPO="~/claude-orchestra"' >> ~/.config/orchestra/orchestra.conf
@@ -132,7 +132,7 @@ chmod +x install.sh
 
 The installer will:
 1. Install `dev` to `~/.local/bin/` (symlinked from repo)
-2. Copy the orchestrator prompts (`CLAUDE.md` and `KIMI.md`) to `~/.config/orchestra/`
+2. Copy worker-safe root prompts plus shared rule files to `~/.config/orchestra/`, and copy orchestrator-only prompts to `~/.config/orchestra/orchestrator/`
 3. Create config at `~/.config/orchestra/projects.conf`
 4. **Ask** if you want Ghostty auto-restore (adds `command` to Ghostty config — works for all tabs/windows)
 5. **Ask** if you want Ghostty Cmd+number keybindings (switch windows with Cmd+0, Cmd+1...)
@@ -231,14 +231,14 @@ Environment variables (set in your shell profile):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORCHESTRA_SESSION` | `devenv` | tmux session name |
-| `ORCHESTRA_DIR` | `~/.config/orchestra` | Where `CLAUDE.md`/`KIMI.md` lives (orchestrator working directory) |
+| `ORCHESTRA_DIR` | `~/.config/orchestra/orchestrator` | Dedicated orchestrator prompt directory and working directory for window 0 |
 | `ORCHESTRA_CONFIG_DIR` | `~/.config/orchestra` | Where `projects.conf` lives (can differ from `ORCHESTRA_DIR`) |
 | `ORCHESTRA_AI` | `claude` | Orchestrator AI type: `claude` or `kimi` |
-| `MAX_AI_SESSIONS` | `3` | Max concurrent AI sessions (Claude + Kimi combined) |
+| `MAX_AI_SESSIONS` | `3` | Max concurrent AI sessions across Claude, Kimi, and Codex workers |
 | `CLAUDE_BIN` | auto-detected | Path to Claude Code binary |
 | `KIMI_BIN` | auto-detected | Path to Kimi CLI binary |
 
-> **Note:** `ORCHESTRA_DIR` and `ORCHESTRA_CONFIG_DIR` default to the same path but serve different purposes. `ORCHESTRA_DIR` controls where the orchestrator AI runs and reads its system prompt. `ORCHESTRA_CONFIG_DIR` controls where the project registry is stored.
+> **Note:** `ORCHESTRA_DIR` and `ORCHESTRA_CONFIG_DIR` now default to different paths. `ORCHESTRA_DIR` controls where the orchestrator AI runs and reads its dedicated prompt files. `ORCHESTRA_CONFIG_DIR` controls where the project registry, worker-safe root instructions, and shared config files live.
 
 ## Commands
 

--- a/WORKER.md
+++ b/WORKER.md
@@ -1,0 +1,35 @@
+# Orchestra Worker Rules
+
+These rules apply to worker sessions started by the orchestra tooling.
+
+## Role
+
+You are a worker AI. Complete engineering tasks inside the assigned project directory. You are not the orchestrator.
+
+## Priorities
+
+- Follow the explicit user task.
+- Follow project-local instruction files in the current project directory.
+- Use these worker rules when local instructions do not conflict.
+
+## Constraints
+
+- Do not coordinate tmux sessions, start other workers, stop workers, or manage orchestra state unless the task explicitly requires changing the orchestra code itself.
+- Do not switch into orchestration mode just because the repository contains orchestra tooling.
+- Stay focused on the assigned project and complete the task end to end when feasible.
+
+## Report Artifacts
+
+If the orchestrator asks for a clash, brainstorming, review, or consensus report, write the result to the requested file instead of relying on terminal output.
+
+- Use the exact filename and path the orchestrator gives you.
+- If no filename is given, use a round-based name like `R1_CLAUDE_DONE.md` or `R1_CODEX_DONE.md`.
+- End the file with a final verdict marker, such as `CLAUDE_DONE_VERDICT: READY` or `CODEX_DONE_VERDICT: NOT READY`.
+- Do not mark the file as `*_DONE.md` until the report is complete.
+- Keep the report concise, concrete, and self-contained so another agent can read it without terminal context.
+
+## Communication
+
+- Be short and direct.
+- Report actions taken, not plans.
+- End completion replies with `DONE: <one-line summary>`.

--- a/dev
+++ b/dev
@@ -52,9 +52,9 @@ _require_codex() {
   fi
 }
 ORCH_SESSION="${ORCHESTRA_SESSION:-devenv}"
-# ORCH_DIR: where CLAUDE.md lives for orchestrator mode
+# ORCH_DIR: dedicated orchestrator prompt directory
 # Override with ORCHESTRA_DIR env var or set in ~/.config/orchestra/orchestra.conf
-ORCH_DIR="${ORCHESTRA_DIR:-$HOME/.config/orchestra}"
+ORCH_DIR="${ORCHESTRA_DIR:-$CONFIG_DIR/orchestrator}"
 MAX_CLAUDE_SESSIONS="${MAX_CLAUDE_SESSIONS:-10}"
 MAX_KIMI_SESSIONS="${MAX_KIMI_SESSIONS:-10}"
 MAX_AI_SESSIONS="${MAX_AI_SESSIONS:-10}"
@@ -259,9 +259,9 @@ _update() {
 
   echo "Will update:"
   echo "  dev                    ~/.local/bin/dev"
-  echo "  CLAUDE.md              ${CONFIG_DIR}/CLAUDE.md"
-  echo "  KIMI.md                ${CONFIG_DIR}/KIMI.md"
-  echo "  MODEL-SELECTION.md     ${CONFIG_DIR}/MODEL-SELECTION.md"
+  echo "  worker prompts         ${CONFIG_DIR}/AGENTS.md, WORKER.md, CLAUDE.md, CODEX.md, KIMI.md"
+  echo "  shared docs            ${CONFIG_DIR}/ORCHESTRATOR.md, MODEL-SELECTION.md, TROUBLESHOOTING.md"
+  echo "  orchestrator prompts   ${ORCH_DIR}/"
   echo ""
   echo "Preserved:"
   echo "  ${CONFIG_DIR}/projects.conf"
@@ -299,10 +299,26 @@ _update() {
 
   [[ "$ok" == "false" ]] && return 1
 
-  # Update orchestrator prompts
-  for f in CLAUDE.md KIMI.md MODEL-SELECTION.md; do
-    if curl -sf "${raw_base}/${f}" -o "${CONFIG_DIR}/${f}" 2>/dev/null; then
+  mkdir -p "${CONFIG_DIR}" "${ORCH_DIR}"
+
+  local prompt_source_root=""
+  if [[ -n "$REPO_ROOT" ]]; then
+    prompt_source_root="$REPO_ROOT"
+  fi
+
+  for f in AGENTS.md WORKER.md CLAUDE.md KIMI.md CODEX.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+    if [[ -n "$prompt_source_root" && -f "${prompt_source_root}/${f}" ]]; then
+      cp "${prompt_source_root}/${f}" "${CONFIG_DIR}/${f}" && echo "  [ok]  ${f} → ${CONFIG_DIR}/${f}"
+    elif curl -sf "${raw_base}/${f}" -o "${CONFIG_DIR}/${f}" 2>/dev/null; then
       echo "  [ok]  ${f} → ${CONFIG_DIR}/${f}"
+    fi
+  done
+
+  for f in AGENTS.md CLAUDE.md KIMI.md CODEX.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+    if [[ -n "$prompt_source_root" && -f "${prompt_source_root}/orchestrator/${f}" ]]; then
+      cp "${prompt_source_root}/orchestrator/${f}" "${ORCH_DIR}/${f}" && echo "  [ok]  orchestrator/${f} → ${ORCH_DIR}/${f}"
+    elif curl -sf "${raw_base}/orchestrator/${f}" -o "${ORCH_DIR}/${f}" 2>/dev/null; then
+      echo "  [ok]  orchestrator/${f} → ${ORCH_DIR}/${f}"
     fi
   done
 
@@ -443,7 +459,7 @@ _ai_launch_cmd() {
   case "$ai" in
     claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions" ;;
     kimi)   echo "'$KIMI_BIN'" ;;
-    codex)  echo "codex exec" ;;
+    codex)  echo "'$CODEX_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "gemini" ;;
     *)      return 1 ;;
@@ -461,6 +477,176 @@ _ai_require() {
     gemini) command -v gemini >/dev/null || { echo "ERROR: gemini not found in PATH"; return 1; } ;;
     *)      echo "ERROR: unknown AI type: $ai (supported: claude, codex, kimi, qwen, gemini)"; return 1 ;;
   esac
+}
+
+_orchestrator_required_reading() {
+  local ai="$1"
+  case "$ai" in
+    claude) echo "AGENTS.md, CLAUDE.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
+    codex)  echo "AGENTS.md, CODEX.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
+    kimi)   echo "AGENTS.md, KIMI.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
+    *) return 1 ;;
+  esac
+}
+
+_orchestrator_start_prompt() {
+  local ai="$1"
+  local files="$(_orchestrator_required_reading "$ai")" || return 1
+  echo "Read $files in this directory before answering or acting. Apply the AGENTS.md and ORCHESTRATOR.md rules as binding instructions. State your role in one sentence, then wait for the user's request."
+}
+
+_worker_start_prompt() {
+  local worker_file="${CONFIG_DIR}/WORKER.md"
+  echo "You are an Orchestra worker AI, not the orchestrator. Follow the shared worker rules in ${worker_file} if that file exists, then follow the local project instructions in the current directory. Stay focused on the assigned project task. Do not manage tmux sessions, start or stop workers, or run dev session-management commands unless the task is explicitly about the orchestra code. End completion replies with DONE: one-line summary."
+}
+
+_worker_launch_cmd() {
+  local ai="$1"
+  local prompt="$(_worker_start_prompt)"
+  case "$ai" in
+    claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --append-system-prompt \"$prompt\"" ;;
+    codex)  echo "'$CODEX_BIN' \"$prompt\"" ;;
+    kimi)   echo "'$KIMI_BIN'" ;;
+    qwen)   echo "qwen" ;;
+    gemini) echo "gemini" ;;
+    *)      return 1 ;;
+  esac
+}
+
+_send_worker_bootstrap_if_needed() {
+  local target="$1"
+  local ai="$2"
+  local prompt="$(_worker_start_prompt)"
+  case "$ai" in
+    claude)
+      local max_wait=15
+      local waited=0
+      while [[ $waited -lt $max_wait ]]; do
+        local pane_cmd
+        pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
+        if [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]]; then
+          break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+      done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
+      ;;
+    kimi)
+      local max_wait=15
+      local waited=0
+      while [[ $waited -lt $max_wait ]]; do
+        local pane_cmd
+        pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
+        if [[ "$pane_cmd" =~ ^[Pp]ython ]] || [[ "$pane_cmd" == "kimi" ]]; then
+          break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+      done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
+      ;;
+  esac
+}
+
+_send_orchestrator_bootstrap_if_needed() {
+  local target="$1"
+  local ai="$2"
+  local prompt="$(_orchestrator_start_prompt "$ai")"
+  case "$ai" in
+    kimi)
+      local max_wait=15
+      local waited=0
+      while [[ $waited -lt $max_wait ]]; do
+        local pane_cmd
+        pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
+        if [[ "$pane_cmd" =~ ^[Pp]ython ]] || [[ "$pane_cmd" == "kimi" ]]; then
+          break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+      done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
+      ;;
+  esac
+}
+
+_ensure_orchestrator_prompt_files() {
+  mkdir -p "$ORCH_DIR" || return 1
+  local files=(AGENTS.md CLAUDE.md KIMI.md CODEX.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md)
+  local repo_root
+  repo_root=$(_find_repo_root)
+  if [[ -n "$repo_root" && -d "$repo_root/orchestrator" ]]; then
+    local f
+    for f in "${files[@]}"; do
+      if [[ -f "$repo_root/orchestrator/$f" && ! -f "$ORCH_DIR/$f" ]]; then
+        cp "$repo_root/orchestrator/$f" "$ORCH_DIR/$f"
+      fi
+    done
+  fi
+
+  local missing=()
+  local f
+  for f in "${files[@]}"; do
+    [[ -f "$ORCH_DIR/$f" ]] || missing+=("$f")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: Missing orchestrator prompt files in ${ORCH_DIR}: ${missing[*]}"
+    return 1
+  fi
+}
+
+_orchestrator_launch_cmd() {
+  local ai="$1"
+  local prompt="$(_orchestrator_start_prompt "$ai")"
+  case "$ai" in
+    codex) echo "cd '$ORCH_DIR' && '$CODEX_BIN' \"$prompt\"" ;;
+    kimi)  echo "cd '$ORCH_DIR' && '$KIMI_BIN'" ;;
+    claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; cd '$ORCH_DIR' && '$CLAUDE_BIN' --dangerously-skip-permissions \"$prompt\"" ;;
+    *) return 1 ;;
+  esac
+}
+
+_pane_index_for_side() {
+  local name="$1"
+  local side="${2:-left}"
+  local panes
+  panes=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_index} #{pane_left}" 2>/dev/null) || return 1
+  [[ -z "$panes" ]] && return 1
+  if [[ "$side" == "right" ]]; then
+    echo "$panes" | sort -k2,2n | tail -1 | awk '{print $1}'
+  else
+    echo "$panes" | sort -k2,2n | head -1 | awk '{print $1}'
+  fi
+}
+
+_pane_target_for_side() {
+  local name="$1"
+  local side="${2:-left}"
+  local idx
+  idx=$(_pane_index_for_side "$name" "$side") || return 1
+  echo "$ORCH_SESSION:$name.$idx"
+}
+
+_window_logfile() {
+  local name="$1"
+  echo "$LOG_DIR/${name}.log"
+}
+
+_pane_logfile_for_side() {
+  local name="$1"
+  local side="${2:-left}"
+  echo "$LOG_DIR/${name}.${side}.log"
+}
+
+_clean_terminal_output() {
+  perl -pe 's/\e\[[0-9;?]*[[:alpha:]]//g; s/\e\][^\a]*\a//g; s/\r/\n/g'
 }
 
 # Detect which AI is running in a specific pane (by index).
@@ -558,6 +744,11 @@ _done() {
 # Helper: check if a window exists in the orchestra session
 _has_window() {
   tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null | grep -qx "$1"
+}
+
+_find_window_conflicts() {
+  local name="$1"
+  tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null | grep -E "^${name}(-[0-9]+|-)?$"
 }
 
 # Helper: ensure the orchestra tmux session exists
@@ -736,7 +927,7 @@ _start_claude() {
     # Window exists but no Claude — attach logger then launch
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
-    tmux send-keys -t "$ORCH_SESSION:$name" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && $(_worker_launch_cmd claude)" Enter
     echo "Launched Claude in existing window: $name"
   else
     # Enforce session limit
@@ -752,7 +943,7 @@ _start_claude() {
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
     sleep 0.5
-    tmux send-keys -t "$ORCH_SESSION:$name" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "$(_worker_launch_cmd claude)" Enter
     echo "Started: $name -> ${dir/$HOME/~}"
   fi
 
@@ -773,6 +964,7 @@ _start_claude() {
     _track_ai_type "$name" "claude"
     _log_history "START $name [window $win_index]"
     echo "Ready: $name [claude] [window $win_index] — switch with Ctrl+A $win_index"
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$name" "claude"
   fi
 }
 
@@ -796,25 +988,39 @@ _start_dual() {
 
   # Resolve launch commands and verify binaries
   local left_cmd right_cmd
-  left_cmd=$(_ai_launch_cmd "$left_ai")  || { echo "ERROR: unknown left AI '$left_ai' (supported: claude, codex, kimi, qwen, gemini)"; return 1; }
-  right_cmd=$(_ai_launch_cmd "$right_ai") || { echo "ERROR: unknown right AI '$right_ai' (supported: claude, codex, kimi, qwen, gemini)"; return 1; }
+  left_cmd=$(_worker_launch_cmd "$left_ai")  || { echo "ERROR: unknown left AI '$left_ai' (supported: claude, codex, kimi, qwen, gemini)"; return 1; }
+  right_cmd=$(_worker_launch_cmd "$right_ai") || { echo "ERROR: unknown right AI '$right_ai' (supported: claude, codex, kimi, qwen, gemini)"; return 1; }
   _ai_require "$left_ai"  || return 1
   _ai_require "$right_ai" || return 1
   _ensure_session || return 1
 
+  local conflicts
+  conflicts=$(_find_window_conflicts "$name")
+  if [[ -n "$conflicts" ]]; then
+    echo "Already running or conflicting window exists for $name:"
+    echo "$conflicts" | sed 's/^/  - /'
+    return 1
+  fi
+
   # Enforce session limit (dual counts as 2)
-  local total_active=$(( $(_claude_count) + $(_kimi_count) ))
-  if [[ $total_active -ge $MAX_AI_SESSIONS ]]; then
+  local total_active=$(( $(_claude_count) + $(_kimi_count) + $(_codex_count) ))
+  if [[ $((total_active + 2)) -gt $MAX_AI_SESSIONS ]]; then
     echo "ERROR: Max $MAX_AI_SESSIONS active AI sessions reached. Kill one first."
     return 1
   fi
 
   # Create window + launch LEFT AI
-  tmux new-window -t "$ORCH_SESSION" -n "$name" -c "$dir"
+  local actual_name
+  actual_name=$(tmux new-window -P -F "#{window_name}" -t "$ORCH_SESSION" -n "$name" -c "$dir" 2>/dev/null)
+  if [[ "$actual_name" != "$name" ]]; then
+    echo "ERROR: tmux created '$actual_name' instead of '$name'. Refusing to continue to avoid duplicate sessions."
+    return 1
+  fi
   mkdir -p "$LOG_DIR"
-  tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
+  tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$(_window_logfile "$name")'"
   sleep 0.5
   tmux send-keys -t "$ORCH_SESSION:$name" "$left_cmd" Enter
+  _send_worker_bootstrap_if_needed "$ORCH_SESSION:$name" "$left_ai"
 
   # Best-effort wait for left AI to appear (process detection is per-AI, keep it simple)
   sleep 2
@@ -822,11 +1028,18 @@ _start_dual() {
   # Split right + launch RIGHT AI
   tmux split-window -h -t "$ORCH_SESSION:$name" -c "$dir"
   sleep 0.3
-  tmux send-keys -t "$ORCH_SESSION:$name.2" "$right_cmd" Enter
+  local left_pane_target
+  left_pane_target=$(_pane_target_for_side "$name" "left") || { echo "ERROR: Failed to resolve left pane for $name"; return 1; }
+  tmux pipe-pane -t "$left_pane_target" -o "cat >> '$(_pane_logfile_for_side "$name" "left")'"
+  local right_pane_target
+  right_pane_target=$(_pane_target_for_side "$name" "right") || { echo "ERROR: Failed to resolve right pane for $name"; return 1; }
+  tmux pipe-pane -t "$right_pane_target" -o "cat >> '$(_pane_logfile_for_side "$name" "right")'"
+  tmux send-keys -t "$right_pane_target" "$right_cmd" Enter
+  _send_worker_bootstrap_if_needed "$right_pane_target" "$right_ai"
   sleep 2
 
   # Select left pane as active
-  tmux select-pane -t "$ORCH_SESSION:$name.1"
+  tmux select-pane -t "$left_pane_target"
 
   local win_index=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_index}:#{window_name}" 2>/dev/null | grep ":${name}$" | cut -d: -f1)
   _track_ai_type "$name" "dual:${left_ai}:${right_ai}"
@@ -864,15 +1077,17 @@ _start_kimi() {
     # Window exists but no Kimi — attach logger then launch
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
-    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && '$KIMI_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && $(_worker_launch_cmd kimi)" Enter
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$name" "kimi"
     echo "Launched Kimi in existing window: $name"
   else
     # Enforce session limit (combined count)
     local claude_active=$(_claude_count)
     local kimi_active=$(_kimi_count)
-    local total_active=$((claude_active + kimi_active))
+    local codex_active=$(_codex_count)
+    local total_active=$((claude_active + kimi_active + codex_active))
     if [[ $total_active -ge $MAX_AI_SESSIONS ]]; then
-      echo "ERROR: Max $MAX_AI_SESSIONS active AI sessions reached (Claude: $claude_active, Kimi: $kimi_active)."
+      echo "ERROR: Max $MAX_AI_SESSIONS active AI sessions reached (Claude: $claude_active, Kimi: $kimi_active, Codex: $codex_active)."
       echo "Kill one first: dev kill <project>"
       return 1
     fi
@@ -882,7 +1097,8 @@ _start_kimi() {
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
     sleep 0.5
-    tmux send-keys -t "$ORCH_SESSION:$name" "'$KIMI_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "$(_worker_launch_cmd kimi)" Enter
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$name" "kimi"
     echo "Started: $name [kimi] -> ${dir/$HOME/~}"
   fi
 
@@ -934,7 +1150,7 @@ _start_codex() {
     fi
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
-    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && '$CODEX_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && $(_worker_launch_cmd codex)" Enter
     echo "Launched Codex in existing window: $name"
   else
     local claude_active=$(_claude_count)
@@ -951,7 +1167,7 @@ _start_codex() {
     mkdir -p "$LOG_DIR"
     tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
     sleep 0.5
-    tmux send-keys -t "$ORCH_SESSION:$name" "'$CODEX_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$name" "$(_worker_launch_cmd codex)" Enter
     echo "Started: $name [codex] -> ${dir/$HOME/~}"
   fi
 
@@ -1013,15 +1229,15 @@ _send() {
   fi
 
   # Determine target pane
-  local pane_target="$ORCH_SESSION:$name.1"
-  if [[ "$target" == "right" ]]; then
-    pane_target="$ORCH_SESSION:$name.2"
-  fi
+  local pane_target
+  pane_target=$(_pane_target_for_side "$name" "$target") || {
+    echo "ERROR: Failed to resolve $target pane for $name"
+    return 1
+  }
 
   # Detect which AI is actually running in the target pane (for logging).
-  # Pane indices: 1 = left, 2 = right (after split-window -h).
-  local pane_idx=1
-  [[ "$target" == "right" ]] && pane_idx=2
+  local pane_idx
+  pane_idx=$(_pane_index_for_side "$name" "$target") || pane_idx=""
   local ai_label=$(_detect_pane_ai "$name" "$pane_idx")
   [[ -z "$ai_label" ]] && ai_label="unknown"
   local ai_type="$ai_label"
@@ -1045,6 +1261,7 @@ _send() {
     rm -f "$tmpfile"
   else
     tmux send-keys -l -t "$pane_target" "$msg"
+    sleep 0.2
     tmux send-keys -t "$pane_target" Enter
   fi
 
@@ -1133,12 +1350,20 @@ _peek() {
   local name=""
   local target="left"
   local lines="50"
+  local source="auto"
+  local raw=false
 
   for arg in "$@"; do
     if [[ "$arg" == "--qwen" || "$arg" == "--right" ]]; then
       target="right"
     elif [[ "$arg" == "--left" ]]; then
       target="left"
+    elif [[ "$arg" == "--log" ]]; then
+      source="log"
+    elif [[ "$arg" == "--screen" ]]; then
+      source="screen"
+    elif [[ "$arg" == "--raw" ]]; then
+      raw=true
     elif [[ -z "$name" ]]; then
       name="$arg"
     elif [[ "$arg" =~ ^[0-9]+$ ]]; then
@@ -1147,7 +1372,7 @@ _peek() {
   done
 
   if [[ -z "$name" ]]; then
-    echo "Usage: dev peek <project> [--qwen|--right|--left] [lines]"
+    echo "Usage: dev peek <project> [--qwen|--right|--left] [--screen] [--raw] [lines]"
     return 1
   fi
 
@@ -1156,19 +1381,51 @@ _peek() {
     return 1
   fi
 
-  local pane_target="$ORCH_SESSION:$name.1"
-  [[ "$target" == "right" ]] && pane_target="$ORCH_SESSION:$name.2"
+  local pane_target
+  pane_target=$(_pane_target_for_side "$name" "$target") || {
+    echo "ERROR: Failed to resolve $target pane for $name"
+    return 1
+  }
 
   _log_history "PEEK $name [$target]"
 
-  # Capture pane content and strip ANSI/TUI garbage
-  tmux capture-pane -t "$pane_target" -p -S "-$lines" | \
-    sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | \
-    sed 's/\x1b\][^\x07]*\x07//g' | \
-    tr -d '\xc2\xa0' | \
-    sed 's/[[:cntrl:]]//g' | \
-    grep -v '^[[:space:]]*$' | \
-    tail -"$lines"
+  local pane_logfile="$(_pane_logfile_for_side "$name" "$target")"
+  local window_logfile="$(_window_logfile "$name")"
+  local logfile="$pane_logfile"
+
+  if [[ "$source" == "auto" ]]; then
+    if [[ -f "$pane_logfile" ]]; then
+      source="log"
+    else
+      source="screen"
+    fi
+  fi
+
+  if [[ "$source" == "log" && ! -f "$logfile" ]]; then
+    if [[ -f "$window_logfile" ]]; then
+      logfile="$window_logfile"
+    else
+      source="screen"
+    fi
+  fi
+
+  if [[ "$source" == "log" && -f "$logfile" ]]; then
+    if [[ "$raw" == true ]]; then
+      tail -n "$lines" "$logfile"
+    else
+      tail -n "$lines" "$logfile" | _clean_terminal_output
+    fi
+    return 0
+  fi
+
+  if [[ "$raw" == true ]]; then
+    tmux capture-pane -J -t "$pane_target" -p -S "-$lines"
+  else
+    tmux capture-pane -J -t "$pane_target" -p -S "-$lines" | \
+      _clean_terminal_output | \
+      grep -v '^[[:space:]]*$' | \
+      tail -"$lines"
+  fi
 }
 
 # Live tail of worker's log file
@@ -1349,6 +1606,7 @@ _recover() {
     # Recover all crashed sessions
     local claude_recovered=0
     local kimi_recovered=0
+    local codex_recovered=0
     if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
       local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}|#{pane_current_command}" 2>/dev/null)
       while IFS='|' read -r wname pcmd; do
@@ -1356,26 +1614,32 @@ _recover() {
         [[ -z "${PROJECTS[$wname]}" ]] && continue
         
         # Check current AI type and recover accordingly
-        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]]; then
+        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]] && [[ ! "$pcmd" =~ $CODEX_PROC_PATTERN ]]; then
           # Window exists but no AI running - determine which AI was there
           local tracked_ai=$(_get_ai_type "$wname")
           local dir="${PROJECTS[$wname]}"
           
-          if [[ "$tracked_ai" == "kimi" ]] || [[ -z "$tracked_ai" && -x "$KIMI_BIN" ]]; then
+          if [[ "$tracked_ai" == "codex" ]]; then
+            echo "Recovering $wname [codex]..."
+            tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && $(_worker_launch_cmd codex)" Enter
+            codex_recovered=$((codex_recovered + 1))
+            _log_history "RECOVER-CODEX $wname"
+          elif [[ "$tracked_ai" == "kimi" ]] || [[ -z "$tracked_ai" && -x "$KIMI_BIN" ]]; then
             echo "Recovering $wname [kimi]..."
-            tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && '$KIMI_BIN'" Enter
+            tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && $(_worker_launch_cmd kimi)" Enter
+            _send_worker_bootstrap_if_needed "$ORCH_SESSION:$wname" "kimi"
             kimi_recovered=$((kimi_recovered + 1))
             _log_history "RECOVER-KIMI $wname"
           else
             echo "Recovering $wname [claude]..."
-            tmux send-keys -t "$ORCH_SESSION:$wname" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --resume" Enter
+            tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && $(_worker_launch_cmd claude) --resume" Enter
             claude_recovered=$((claude_recovered + 1))
             _log_history "RECOVER $wname"
           fi
         fi
       done <<< "$windows"
     fi
-    echo "Recovered $((claude_recovered + kimi_recovered)) sessions (Claude: $claude_recovered, Kimi: $kimi_recovered)."
+    echo "Recovered $((claude_recovered + kimi_recovered + codex_recovered)) sessions (Claude: $claude_recovered, Kimi: $kimi_recovered, Codex: $codex_recovered)."
     return 0
   fi
 
@@ -1415,7 +1679,8 @@ _recover() {
   # Determine which AI to recover
   if [[ "$tracked_ai" == "kimi" ]]; then
     echo "Recovering $target [kimi]..."
-    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && '$KIMI_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && $(_worker_launch_cmd kimi)" Enter
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$target" "kimi"
     _log_history "RECOVER-KIMI $target"
 
     local max_wait=15
@@ -1436,7 +1701,7 @@ _recover() {
     fi
   elif [[ "$tracked_ai" == "codex" ]]; then
     echo "Recovering $target [codex]..."
-    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && '$CODEX_BIN'" Enter
+    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && $(_worker_launch_cmd codex)" Enter
     _log_history "RECOVER-CODEX $target"
 
     local max_wait=15
@@ -1456,7 +1721,7 @@ _recover() {
     fi
   else
     echo "Recovering $target [claude]..."
-    tmux send-keys -t "$ORCH_SESSION:$target" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --resume" Enter
+    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && $(_worker_launch_cmd claude) --resume" Enter
     _log_history "RECOVER $target"
 
     local max_wait=15
@@ -1480,112 +1745,15 @@ _recover() {
 # Start orchestrator: create master session, open Claude, Kimi, or Codex in window 0
 _orchestra() {
   _ensure_session || return 1
+  _ensure_orchestrator_prompt_files || return 1
 
   # Check which orchestrator to use (default: Claude)
   local orch_ai="${ORCHESTRA_AI:-claude}"
-  local orch_bin=""
-  local orch_file=""
-
-  if [[ "$orch_ai" == "codex" ]]; then
-    _require_codex || return 1
-    orch_bin="$CODEX_BIN"
-    orch_file="$ORCH_DIR/CODEX.md"
-    if [[ ! -f "$orch_file" ]]; then
-      cat > "$orch_file" << 'CODEXEOF'
-# Orchestra - Codex Orchestrator
-
-## Communication
-- Be short and direct
-- Report actions taken, not plans
-
-## Role
-You are the orchestrator Codex. You manage multiple Codex worker sessions from this single terminal via tmux windows.
-
-## Startup Sequence
-1. Run `~/.local/bin/dev status` to check current state
-2. Ask the user which projects they want to work on
-3. Start sessions with: `dev codex start <project>`
-
-## Commands (always use full path)
-```bash
-~/.local/bin/dev codex start <alias>      # Start a Codex session
-~/.local/bin/dev send <alias> "message"   # Send a task/message
-~/.local/bin/dev peek <alias>             # Read worker's recent output
-~/.local/bin/dev broadcast "message"      # Send to ALL active AI sessions
-~/.local/bin/dev kill <alias>             # Kill a project window
-~/.local/bin/dev list                     # List all projects
-~/.local/bin/dev status                   # Show active windows
-~/.local/bin/dev done <alias>             # Check if worker is idle
-~/.local/bin/dev wait <alias>             # Wait for worker to finish
-```
-
-## Task Lifecycle
-1. **Send task:** `dev send <alias> "detailed task description"`
-2. **Wait:** `sleep 20`
-3. **Check output:** `dev peek <alias>` to read the worker's response
-4. **Still working?** If worker is still busy, `sleep 15` and `dev peek` again
-5. **Report to user:** Summarize what the worker did or said
-
-## Rules
-- Max $MAX_AI_SESSIONS concurrent AI sessions total
-- Include full context in every message to workers
-- Workers have zero knowledge of this conversation
-- Always tell the user the window number after starting
-CODEXEOF
-    fi
-  elif [[ "$orch_ai" == "kimi" ]]; then
-    _require_kimi || return 1
-    orch_bin="$KIMI_BIN"
-    orch_file="$ORCH_DIR/KIMI.md"
-    # Create KIMI.md if it doesn't exist
-    if [[ ! -f "$orch_file" ]]; then
-      cat > "$orch_file" << 'KIMIEOF'
-# Orchestra - Kimi CLI Orchestrator
-
-## Communication
-- Be short and direct
-- Report actions taken, not plans
-
-## Role
-You are the orchestrator Kimi. You manage multiple Kimi CLI worker sessions from this single terminal via tmux windows.
-
-## Startup Sequence
-1. Run `~/.local/bin/dev status` to check current state
-2. Ask the user which projects they want to work on
-3. Start sessions with: `dev kimi start <project>`
-
-## Commands (always use full path via Bash tool)
-```bash
-~/.local/bin/dev kimi start <alias>       # Start a Kimi session
-~/.local/bin/dev send <alias> "message"   # Send a task/message (auto-detects AI type)
-~/.local/bin/dev peek <alias>             # Read worker's recent output
-~/.local/bin/dev broadcast "message"      # Send to ALL active AI sessions
-~/.local/bin/dev kill <alias>             # Kill a project window
-~/.local/bin/dev list                     # List all projects
-~/.local/bin/dev status                   # Show active windows
-~/.local/bin/dev done <alias>             # Check if worker is idle
-~/.local/bin/dev wait <alias>             # Wait for worker to finish
-```
-
-## Task Lifecycle
-1. **Send task:** `dev send <alias> "detailed task description"`
-2. **Wait:** `sleep 20`
-3. **Check output:** `dev peek <alias>` to read the worker's response
-4. **Still working?** If worker is still busy, `sleep 15` and `dev peek` again
-5. **Report to user:** Summarize what the worker did or said
-
-## Rules
-- Max $MAX_AI_SESSIONS concurrent AI sessions (Claude + Kimi combined)
-- Include full context in every message to workers
-- Workers have zero knowledge of this conversation
-- Always tell the user the window number after starting
-KIMIEOF
-    fi
-  else
-    _require_claude || return 1
-    orch_bin="$CLAUDE_BIN"
-    orch_file="$ORCH_DIR/CLAUDE.md"
-  fi
+  case "$orch_ai" in
+    codex) _require_codex || return 1 ;;
+    kimi)  _require_kimi || return 1 ;;
+    *)     _require_claude || return 1 ;;
+  esac
 
   # Check what's currently running in orchestra window
   local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:orchestra" -F "#{pane_current_command}" 2>/dev/null | head -1)
@@ -1616,13 +1784,14 @@ KIMIEOF
   # Launch AI if not already running
   if [[ "$current_ai" != "$orch_ai" ]]; then
     if [[ "$orch_ai" == "kimi" ]]; then
-      tmux send-keys -t "$ORCH_SESSION:orchestra" "cd '$ORCH_DIR' && '$orch_bin'" Enter
+      tmux send-keys -t "$ORCH_SESSION:orchestra" "$(_orchestrator_launch_cmd kimi)" Enter
+      _send_orchestrator_bootstrap_if_needed "$ORCH_SESSION:orchestra" "kimi"
       echo "Starting Kimi orchestrator..."
     elif [[ "$orch_ai" == "codex" ]]; then
-      tmux send-keys -t "$ORCH_SESSION:orchestra" "cd '$ORCH_DIR' && '$orch_bin'" Enter
+      tmux send-keys -t "$ORCH_SESSION:orchestra" "$(_orchestrator_launch_cmd codex)" Enter
       echo "Starting Codex orchestrator..."
     else
-      tmux send-keys -t "$ORCH_SESSION:orchestra" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; cd '$ORCH_DIR' && '$orch_bin' --dangerously-skip-permissions" Enter
+      tmux send-keys -t "$ORCH_SESSION:orchestra" "$(_orchestrator_launch_cmd claude)" Enter
       echo "Starting Claude orchestrator..."
     fi
     sleep 1

--- a/dev
+++ b/dev
@@ -20,6 +20,7 @@ CONFIG_DIR="${ORCHESTRA_CONFIG_DIR:-$HOME/.config/orchestra}"
 PROJECTS_FILE="$CONFIG_DIR/projects.conf"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo "$HOME/.local/bin/claude")}"
 KIMI_BIN="${KIMI_BIN:-$(command -v kimi 2>/dev/null || echo "$HOME/.local/bin/kimi")}"
+CODEX_BIN="${CODEX_BIN:-$(command -v codex 2>/dev/null || echo "$HOME/.local/bin/codex")}"
 
 # AI window tracking file (stores which AI is running in each window)
 AI_TRACK_FILE="$CONFIG_DIR/.ai_windows"
@@ -41,6 +42,15 @@ _require_kimi() {
     return 1
   fi
 }
+
+# Validate CODEX_BIN
+_require_codex() {
+  if [[ ! -x "$CODEX_BIN" ]]; then
+    echo "ERROR: Codex binary not found or not executable: $CODEX_BIN"
+    echo "Install Codex CLI: npm install -g @openai/codex"
+    return 1
+  fi
+}
 ORCH_SESSION="${ORCHESTRA_SESSION:-devenv}"
 # ORCH_DIR: where CLAUDE.md lives for orchestrator mode
 # Override with ORCHESTRA_DIR env var or set in ~/.config/orchestra/orchestra.conf
@@ -52,6 +62,8 @@ MAX_AI_SESSIONS="${MAX_AI_SESSIONS:-10}"
 CLAUDE_PROC_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+$"
 # Kimi CLI process detection (Python process with kimi module)
 KIMI_PROC_PATTERN="(kimi|python.*kimi)"
+# Codex CLI runs as a node process
+CODEX_PROC_PATTERN="^node$"
 LOG_DIR="${HOME}/.local/share/orchestra/logs"
 HISTORY_FILE="${HOME}/.local/share/orchestra/history.log"
 
@@ -343,10 +355,24 @@ _kimi_count() {
   echo "$count"
 }
 
+# Helper: count active Codex windows in the orchestra session
+_codex_count() {
+  local count=0
+  if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
+    local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null)
+    while IFS= read -r wname; do
+      [[ "$wname" == "orchestra" ]] && continue
+      local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$wname" -F "#{pane_current_command}" 2>/dev/null | head -1)
+      [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]] && count=$((count + 1))
+    done <<< "$windows"
+  fi
+  echo "$count"
+}
+
 # AI type tracking per window
 _track_ai_type() {
   local window="$1"
-  local ai_type="$2"  # "claude" or "kimi"
+  local ai_type="$2"  # "claude", "kimi", or "codex"
   mkdir -p "$(dirname "$AI_TRACK_FILE")"
   # Remove existing entry for this window and add new one
   grep -v "^${window}:" "$AI_TRACK_FILE" 2>/dev/null > "$AI_TRACK_FILE.tmp" || true
@@ -378,11 +404,13 @@ _get_ai_type() {
 _detect_ai_type() {
   local name="$1"
   local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
-  
+
   if [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]]; then
     echo "claude"
   elif [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then
     echo "kimi"
+  elif [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
+    echo "codex"
   else
     echo ""
   fi
@@ -394,6 +422,7 @@ _is_ai_running() {
   local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
   if [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]]; then return 0; fi
   if [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then return 0; fi
+  if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then return 0; fi
   return 1
 }
 
@@ -402,6 +431,7 @@ _get_ai_bin() {
   case "$ai_type" in
     claude) echo "$CLAUDE_BIN" ;;
     kimi) echo "$KIMI_BIN" ;;
+    codex) echo "$CODEX_BIN" ;;
     *) echo "" ;;
   esac
 }
@@ -670,6 +700,8 @@ _start() {
     local orch_ai=$(_get_orchestrator_ai)
     if [[ "$orch_ai" == "kimi" ]]; then
       _start_kimi "$name"
+    elif [[ "$orch_ai" == "codex" ]]; then
+      _start_codex "$name"
     else
       _start_claude "$name"
     fi
@@ -875,7 +907,75 @@ _start_kimi() {
   fi
 }
 
-# Send a message to an AI window (Claude or Kimi)
+# Start Codex in a new window within the orchestra session
+_start_codex() {
+  local name="$1"
+  local dir="${PROJECTS[$name]}"
+
+  if [[ -z "$dir" ]]; then
+    echo "Unknown project: $name"
+    return 1
+  fi
+
+  if [[ ! -d "$dir" ]]; then
+    echo "Directory not found: $dir"
+    return 1
+  fi
+
+  _require_codex || return 1
+  _ensure_session || return 1
+
+  # If window exists, check if Codex is running
+  if _has_window "$name"; then
+    local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
+    if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
+      echo "Already running: $name [codex]"
+      return 0
+    fi
+    mkdir -p "$LOG_DIR"
+    tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
+    tmux send-keys -t "$ORCH_SESSION:$name" "cd '$dir' && '$CODEX_BIN'" Enter
+    echo "Launched Codex in existing window: $name"
+  else
+    local claude_active=$(_claude_count)
+    local kimi_active=$(_kimi_count)
+    local codex_active=$(_codex_count)
+    local total_active=$((claude_active + kimi_active + codex_active))
+    if [[ $total_active -ge $MAX_AI_SESSIONS ]]; then
+      echo "ERROR: Max $MAX_AI_SESSIONS active AI sessions reached."
+      echo "Kill one first: dev kill <project>"
+      return 1
+    fi
+
+    tmux new-window -t "$ORCH_SESSION" -n "$name" -c "$dir"
+    mkdir -p "$LOG_DIR"
+    tmux pipe-pane -t "$ORCH_SESSION:$name" -o "cat >> '$LOG_DIR/${name}.log'"
+    sleep 0.5
+    tmux send-keys -t "$ORCH_SESSION:$name" "'$CODEX_BIN'" Enter
+    echo "Started: $name [codex] -> ${dir/$HOME/~}"
+  fi
+
+  # Wait for Codex to be ready (poll for node process, max 15s)
+  local max_wait=15
+  local waited=0
+  while [[ $waited -lt $max_wait ]]; do
+    local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
+    [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]] && break
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if [[ $waited -ge $max_wait ]]; then
+    echo "WARNING: Codex may not be ready in $name (waited ${max_wait}s)"
+  else
+    local win_index=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_index}:#{window_name}" 2>/dev/null | grep ":${name}$" | cut -d: -f1)
+    _track_ai_type "$name" "codex"
+    _log_history "START-CODEX $name [window $win_index]"
+    echo "Ready: $name [codex] [window $win_index] — switch with Ctrl+A $win_index"
+  fi
+}
+
+# Send a message to an AI window (Claude, Kimi, or Codex)
 _send() {
   local name=""
   local target="left"
@@ -971,6 +1071,8 @@ _status() {
         sess_state="claude"
       elif [[ "$pcmd" =~ ^python ]] || [[ "$pcmd" == "kimi" ]]; then
         sess_state="kimi"
+      elif [[ "$pcmd" =~ $CODEX_PROC_PATTERN ]]; then
+        sess_state="codex"
       fi
       printf "  %-4s %-18s %-12s %s\n" "$idx" "$wname" "[$sess_state]" "${dir/$HOME/~}"
     done <<< "$windows"
@@ -980,7 +1082,8 @@ _status() {
   echo ""
   local claude_count=$(_claude_count)
   local kimi_count=$(_kimi_count)
-  echo "  Claude sessions: $claude_count | Kimi sessions: $kimi_count | Max: $MAX_AI_SESSIONS"
+  local codex_count=$(_codex_count)
+  echo "  Claude sessions: $claude_count | Kimi sessions: $kimi_count | Codex sessions: $codex_count | Max: $MAX_AI_SESSIONS"
   echo ""
 }
 
@@ -994,6 +1097,7 @@ _broadcast() {
 
   local claude_count=0
   local kimi_count=0
+  local codex_count=0
   local skipped=0
   if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
     local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null)
@@ -1007,6 +1111,9 @@ _broadcast() {
       elif [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then
         is_ai=true
         kimi_count=$((kimi_count + 1))
+      elif [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
+        is_ai=true
+        codex_count=$((codex_count + 1))
       fi
       
       if [[ "$is_ai" == true ]]; then
@@ -1300,14 +1407,17 @@ _recover() {
     echo "$target: Kimi is already running"
     return 0
   fi
-  
+  if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
+    echo "$target: Codex is already running"
+    return 0
+  fi
+
   # Determine which AI to recover
   if [[ "$tracked_ai" == "kimi" ]]; then
     echo "Recovering $target [kimi]..."
     tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && '$KIMI_BIN'" Enter
     _log_history "RECOVER-KIMI $target"
-    
-    # Wait for readiness
+
     local max_wait=15
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
@@ -1317,19 +1427,38 @@ _recover() {
       sleep 1
       waited=$((waited + 1))
     done
-    
+
     if [[ $waited -ge $max_wait ]]; then
       echo "WARNING: Kimi may not be ready in $target"
     else
       echo "Recovered: $target [kimi]"
       _notify "$target" "Kimi session recovered"
     fi
+  elif [[ "$tracked_ai" == "codex" ]]; then
+    echo "Recovering $target [codex]..."
+    tmux send-keys -t "$ORCH_SESSION:$target" "cd '$dir' && '$CODEX_BIN'" Enter
+    _log_history "RECOVER-CODEX $target"
+
+    local max_wait=15
+    local waited=0
+    while [[ $waited -lt $max_wait ]]; do
+      pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$target" -F "#{pane_current_command}" 2>/dev/null | head -1)
+      [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]] && break
+      sleep 1
+      waited=$((waited + 1))
+    done
+
+    if [[ $waited -ge $max_wait ]]; then
+      echo "WARNING: Codex may not be ready in $target"
+    else
+      echo "Recovered: $target [codex]"
+      _notify "$target" "Codex session recovered"
+    fi
   else
     echo "Recovering $target [claude]..."
     tmux send-keys -t "$ORCH_SESSION:$target" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --resume" Enter
     _log_history "RECOVER $target"
 
-    # Wait for readiness
     local max_wait=15
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
@@ -1348,7 +1477,7 @@ _recover() {
   fi
 }
 
-# Start orchestrator: create master session, open Claude or Kimi in window 0
+# Start orchestrator: create master session, open Claude, Kimi, or Codex in window 0
 _orchestra() {
   _ensure_session || return 1
 
@@ -1356,8 +1485,55 @@ _orchestra() {
   local orch_ai="${ORCHESTRA_AI:-claude}"
   local orch_bin=""
   local orch_file=""
-  
-  if [[ "$orch_ai" == "kimi" ]]; then
+
+  if [[ "$orch_ai" == "codex" ]]; then
+    _require_codex || return 1
+    orch_bin="$CODEX_BIN"
+    orch_file="$ORCH_DIR/CODEX.md"
+    if [[ ! -f "$orch_file" ]]; then
+      cat > "$orch_file" << 'CODEXEOF'
+# Orchestra - Codex Orchestrator
+
+## Communication
+- Be short and direct
+- Report actions taken, not plans
+
+## Role
+You are the orchestrator Codex. You manage multiple Codex worker sessions from this single terminal via tmux windows.
+
+## Startup Sequence
+1. Run `~/.local/bin/dev status` to check current state
+2. Ask the user which projects they want to work on
+3. Start sessions with: `dev codex start <project>`
+
+## Commands (always use full path)
+```bash
+~/.local/bin/dev codex start <alias>      # Start a Codex session
+~/.local/bin/dev send <alias> "message"   # Send a task/message
+~/.local/bin/dev peek <alias>             # Read worker's recent output
+~/.local/bin/dev broadcast "message"      # Send to ALL active AI sessions
+~/.local/bin/dev kill <alias>             # Kill a project window
+~/.local/bin/dev list                     # List all projects
+~/.local/bin/dev status                   # Show active windows
+~/.local/bin/dev done <alias>             # Check if worker is idle
+~/.local/bin/dev wait <alias>             # Wait for worker to finish
+```
+
+## Task Lifecycle
+1. **Send task:** `dev send <alias> "detailed task description"`
+2. **Wait:** `sleep 20`
+3. **Check output:** `dev peek <alias>` to read the worker's response
+4. **Still working?** If worker is still busy, `sleep 15` and `dev peek` again
+5. **Report to user:** Summarize what the worker did or said
+
+## Rules
+- Max $MAX_AI_SESSIONS concurrent AI sessions total
+- Include full context in every message to workers
+- Workers have zero knowledge of this conversation
+- Always tell the user the window number after starting
+CODEXEOF
+    fi
+  elif [[ "$orch_ai" == "kimi" ]]; then
     _require_kimi || return 1
     orch_bin="$KIMI_BIN"
     orch_file="$ORCH_DIR/KIMI.md"
@@ -1420,8 +1596,10 @@ KIMIEOF
     current_ai="claude"
   elif [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then
     current_ai="kimi"
+  elif [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
+    current_ai="codex"
   fi
-  
+
   # If a different AI is running, kill it first
   if [[ -n "$current_ai" && "$current_ai" != "$orch_ai" ]]; then
     echo "Switching orchestrator from $current_ai to $orch_ai..."
@@ -1431,15 +1609,18 @@ KIMIEOF
     sleep 0.2
     current_ai=""
   fi
-  
+
   # Save orchestrator AI type
   _set_orchestrator_ai "$orch_ai"
-  
+
   # Launch AI if not already running
   if [[ "$current_ai" != "$orch_ai" ]]; then
     if [[ "$orch_ai" == "kimi" ]]; then
       tmux send-keys -t "$ORCH_SESSION:orchestra" "cd '$ORCH_DIR' && '$orch_bin'" Enter
       echo "Starting Kimi orchestrator..."
+    elif [[ "$orch_ai" == "codex" ]]; then
+      tmux send-keys -t "$ORCH_SESSION:orchestra" "cd '$ORCH_DIR' && '$orch_bin'" Enter
+      echo "Starting Codex orchestrator..."
     else
       tmux send-keys -t "$ORCH_SESSION:orchestra" "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; cd '$ORCH_DIR' && '$orch_bin' --dangerously-skip-permissions" Enter
       echo "Starting Claude orchestrator..."
@@ -1492,6 +1673,36 @@ case "$1" in
         ;;
     esac
     ;;
+  codex)
+    # Codex subcommands
+    case "$2" in
+      start)      _start_codex "$3" ;;
+      send)       _send "$3" "${@:4}" ;;
+      peek)       _peek "$3" "$4" ;;
+      status)     _status ;;
+      broadcast)  _broadcast "${@:3}" ;;
+      watch)      _watch "$3" ;;
+      wait)       _wait "$3" "$4" ;;
+      ask)        _ask "$3" "${@:4}" ;;
+      done)       _done "$3" ;;
+      recover)    _recover "$3" ;;
+      "")         ORCHESTRA_AI=codex _orchestra ;;  # Start Codex orchestrator
+      *)
+        echo "Codex commands:"
+        echo "  dev codex                  Start Codex orchestrator"
+        echo "  dev codex start <project>  Start Codex in a window"
+        echo "  dev codex send <p> <msg>   Send message to project's Codex"
+        echo "  dev codex peek <p> [lines] Read Codex's recent output"
+        echo "  dev codex status           Show Codex windows status"
+        echo "  dev codex broadcast <msg>  Send to all Codex sessions"
+        echo "  dev codex watch <project>  Live tail of Codex's log"
+        echo "  dev codex wait <p> [sec]   Wait for Codex to finish"
+        echo "  dev codex ask <p> <msg>    Send question to Codex"
+        echo "  dev codex done <project>   Check if Codex is idle"
+        echo "  dev codex recover <p>      Recover crashed Codex session"
+        ;;
+    esac
+    ;;
   send)           _send "${@:2}" ;;
   status)         _status ;;
   broadcast)      _broadcast "${@:2}" ;;
@@ -1512,11 +1723,13 @@ case "$1" in
     echo "Usage:"
     echo "  dev                        Start Claude orchestrator (shortcut)"
     echo "  dev kimi                   Start Kimi orchestrator"
+    echo "  dev codex                  Start Codex orchestrator"
     echo "  dev orchestra              Start orchestrator (master session)"
     echo "  dev start <project>        Start Claude in a window (max $MAX_AI_SESSIONS total)"
     echo "  dev start <p> --dual [L] [R]  Dual pane, any AI combo (default: claude codex)"
     echo "                               L/R ∈ {claude, codex, kimi, qwen, gemini}"
     echo "  dev kimi start <project>   Start Kimi in a window"
+    echo "  dev codex start <project>  Start Codex in a window"
     echo "  dev send <p> [--right|--qwen|--left] <msg>   Send message (right pane in dual)"
     echo "  dev peek <p> [--right|--qwen|--left] [lines] Read output (right pane in dual)"
     echo "  dev broadcast <msg>        Send to all active AI sessions"

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,23 @@ fi
 # ── Create directories ───────────────────────────────────────────
 mkdir -p "${INSTALL_DIR}"
 mkdir -p "${CONFIG_DIR}"
+mkdir -p "${CONFIG_DIR}/orchestrator"
+
+# ── Install worker-safe prompt and shared rule files ─────────────
+for f in AGENTS.md WORKER.md CLAUDE.md KIMI.md CODEX.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+  if [[ -f "${ORCH_DIR}/${f}" ]]; then
+    cp "${ORCH_DIR}/${f}" "${CONFIG_DIR}/${f}"
+    echo "Installed: ${CONFIG_DIR}/${f}"
+  fi
+done
+
+# ── Install dedicated orchestrator prompt directory ──────────────
+for f in AGENTS.md CLAUDE.md KIMI.md CODEX.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+  if [[ -f "${ORCH_DIR}/orchestrator/${f}" ]]; then
+    cp "${ORCH_DIR}/orchestrator/${f}" "${CONFIG_DIR}/orchestrator/${f}"
+    echo "Installed: ${CONFIG_DIR}/orchestrator/${f}"
+  fi
+done
 
 # ── Symlink dev ──────────────────────────────────────────────────
 if [[ -L "${INSTALL_DIR}/dev" || -f "${INSTALL_DIR}/dev" ]]; then

--- a/orchestrator/AGENTS.md
+++ b/orchestrator/AGENTS.md
@@ -1,0 +1,5 @@
+# Orchestra Codex Orchestrator Bootstrap
+
+You are the orchestra orchestrator running from the dedicated `orchestrator/` prompt directory.
+
+Read `CODEX.md`, `ORCHESTRATOR.md`, `MODEL-SELECTION.md`, and `TROUBLESHOOTING.md` in this directory before acting. Apply the orchestrator rules, not the worker rules from the repo root.

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -1,0 +1,23 @@
+# Orchestra - Claude Orchestrator
+
+## Role
+
+You are the orchestra orchestrator for Claude workers.
+
+## Required Reading
+
+Read these files in this directory before acting:
+
+- `ORCHESTRATOR.md`
+- `MODEL-SELECTION.md`
+- `TROUBLESHOOTING.md`
+
+## Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Run `~/.local/bin/dev status` on startup.
+- Ask which projects to work on before starting workers.
+- Start Claude workers with `~/.local/bin/dev start <alias>`.
+- Do not write code in the orchestrator session.
+- After every `dev send`, follow up with a real wait and `dev peek`/`dev wait`.

--- a/orchestrator/CODEX.md
+++ b/orchestrator/CODEX.md
@@ -1,0 +1,30 @@
+# Orchestra - Codex Orchestrator
+
+## Role
+
+You are the orchestrator Codex. You manage worker sessions from this terminal, dispatch tasks, monitor them, and report back to the user.
+
+## Required Reading
+
+Read these files in this directory before acting:
+
+- `AGENTS.md`
+- `ORCHESTRATOR.md`
+- `MODEL-SELECTION.md`
+- `TROUBLESHOOTING.md`
+
+## Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Run `~/.local/bin/dev status` on startup.
+- Ask the user which projects to work on before starting workers.
+- Start Codex workers with `~/.local/bin/dev codex start <alias>`.
+- Do not write code in the orchestrator session. Delegate implementation, shell work, tests, and file edits to workers.
+- After every `dev send`, follow up with a real wait and `dev peek`/`dev wait`.
+
+## Model Selection
+
+- Strategic orchestration and cross-project synthesis: `GPT-5.5`
+- Normal Codex worker implementation and review: `gpt-5.4`
+- Cheap watch, extract, and formatting work: `gpt-5.4-mini`

--- a/orchestrator/KIMI.md
+++ b/orchestrator/KIMI.md
@@ -1,0 +1,23 @@
+# Orchestra - Kimi Orchestrator
+
+## Role
+
+You are the orchestra orchestrator for Kimi workers.
+
+## Required Reading
+
+Read these files in this directory before acting:
+
+- `ORCHESTRATOR.md`
+- `MODEL-SELECTION.md`
+- `TROUBLESHOOTING.md`
+
+## Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Run `~/.local/bin/dev status` on startup.
+- Ask which projects to work on before starting workers.
+- Start Kimi workers with `~/.local/bin/dev kimi start <alias>`.
+- Do not write code in the orchestrator session.
+- After every `dev send`, follow up with a real wait and `dev peek`/`dev wait`.

--- a/orchestrator/MODEL-SELECTION.md
+++ b/orchestrator/MODEL-SELECTION.md
@@ -1,0 +1,13 @@
+# Orchestra Model Selection
+
+## Codex
+
+- Strategic orchestration and cross-project synthesis: `GPT-5.5`
+- Worker implementation and review: `gpt-5.4`
+- Cheap watch, extract, and formatting work: `gpt-5.4-mini`
+
+## Claude
+
+- Strategic orchestration: Opus
+- Worker implementation and review: Sonnet
+- Cheap watch, extract, and formatting work: Haiku

--- a/orchestrator/ORCHESTRATOR.md
+++ b/orchestrator/ORCHESTRATOR.md
@@ -1,0 +1,22 @@
+# Orchestra - Shared Orchestrator Rules
+
+## Role
+
+You are the orchestrator. You coordinate workers, not implementation.
+
+## Core Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Never kill workers without explicit user approval.
+- Never write code in the orchestrator session.
+- Always include full task context when sending work to a worker.
+- After every `dev send`, wait and check output in the same response.
+
+## Workflow
+
+1. Check status with `~/.local/bin/dev status`
+2. Ask which projects to work on
+3. Start workers with the AI-specific `dev` command
+4. Monitor them with `dev peek`, `dev wait`, and `dev done`
+5. Report worker output back to the user

--- a/orchestrator/TROUBLESHOOTING.md
+++ b/orchestrator/TROUBLESHOOTING.md
@@ -1,0 +1,3 @@
+# Orchestra Troubleshooting
+
+Use the repo-root `../TROUBLESHOOTING.md` guide for full troubleshooting details. This duplicate exists so the dedicated orchestrator prompt directory has the expected file names available at startup.


### PR DESCRIPTION
## Summary

Adds OpenAI Codex CLI as a first-class orchestrator and worker alongside Claude and Kimi.

- **`dev codex`** — start Codex orchestrator (mirrors `dev kimi`)
- **`dev codex start <project>`** — start Codex worker in a project window
- **`ORCHESTRA_AI=codex dev`** — env-var alternative
- **`CODEX.md`** — auto-generated orchestrator prompt on first launch
- Codex sessions appear as `[codex]` in `dev status` with their own session counter

## Changes

| Area | What changed |
|---|---|
| Config | `CODEX_BIN` auto-detect, `_require_codex`, `CODEX_PROC_PATTERN` (`node`) |
| Counting | `_codex_count` helper; `dev status` shows `Codex sessions: N` |
| Workers | `_start_codex` (mirrors `_start_kimi`); `_start` routes to it when orchestrator is codex |
| Orchestrator | `_orchestra` handles `codex` branch, creates `CODEX.md` scaffold |
| Detection | `_detect_ai_type`, `_is_ai_running`, `_get_ai_bin` updated for codex |
| Broadcast | `_broadcast` counts and includes Codex windows |
| Recovery | `_recover` has Codex branch |
| CLI | `dev codex [start|send|peek|status|broadcast|watch|wait|ask|done|recover]` |
| Help | Updated to list `dev codex` and `dev codex start` |

## Install Codex CLI

```bash
npm install -g @openai/codex
```

## Test plan

- [ ] `dev codex` — launches Codex orchestrator in window 0
- [ ] `dev codex start <project>` — starts Codex worker, shows `[codex]`
- [ ] `dev status` — shows `Codex sessions: N`
- [ ] `dev send <project> "msg"` — auto-detects Codex and delivers message
- [ ] `dev peek <project>` — reads Codex output
- [ ] `dev recover <project>` — recovers crashed Codex session
- [ ] `dev broadcast "msg"` — reaches Codex windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)