### PR TITLE
feat: restore worker status indicator + tmux/ghostty config installers

### DIFF
--- a/dev
+++ b/dev
@@ -299,6 +299,17 @@ _update() {
 
   [[ "$ok" == "false" ]] && return 1
 
+  # Re-link orchestra-status helper (worker idle/busy indicators)
+  if [[ "$dev_mode" == "symlink" ]] && [[ -n "$REPO_ROOT" ]] && [[ -f "${REPO_ROOT}/orchestra-status.sh" ]]; then
+    chmod +x "${REPO_ROOT}/orchestra-status.sh"
+    if [[ ! -L "${HOME}/.local/bin/orchestra-status" ]] || \
+       [[ "$(readlink "${HOME}/.local/bin/orchestra-status")" != "${REPO_ROOT}/orchestra-status.sh" ]]; then
+      rm -f "${HOME}/.local/bin/orchestra-status"
+      ln -s "${REPO_ROOT}/orchestra-status.sh" "${HOME}/.local/bin/orchestra-status" \
+        && echo "  [ok]  orchestra-status → ${HOME}/.local/bin/orchestra-status"
+    fi
+  fi
+
   mkdir -p "${CONFIG_DIR}" "${ORCH_DIR}"
 
   local prompt_source_root=""

--- a/ghostty.example.conf
+++ b/ghostty.example.conf
@@ -1,0 +1,24 @@
+# Ghostty keybindings for Claude Orchestra
+# Add these to your ~/.config/ghostty/config
+#
+# IMPORTANT: These assume tmux prefix is Ctrl+A (\x01).
+# If you use the default Ctrl+B prefix, replace \x01 with \x02 below.
+#
+# To set Ctrl+A as tmux prefix, see tmux.example.conf or add to ~/.tmux.conf:
+#   unbind C-b
+#   set -g prefix C-a
+#   bind C-a send-prefix
+#
+# Maps Cmd+0-9 to tmux prefix + number
+# so you can switch tmux windows with Cmd+number
+
+keybind = super+zero=text:\x010
+keybind = super+one=text:\x011
+keybind = super+two=text:\x012
+keybind = super+three=text:\x013
+keybind = super+four=text:\x014
+keybind = super+five=text:\x015
+keybind = super+six=text:\x016
+keybind = super+seven=text:\x017
+keybind = super+eight=text:\x018
+keybind = super+nine=text:\x019

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ set -e
 INSTALL_DIR="${HOME}/.local/bin"
 CONFIG_DIR="${HOME}/.config/orchestra"
 GHOSTTY_CONFIG="${HOME}/.config/ghostty/config"
+TMUX_CONFIG="${HOME}/.tmux.conf"
 ORCH_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "Claude Orchestra installer"
@@ -66,6 +67,16 @@ if [[ -L "${INSTALL_DIR}/dev" || -f "${INSTALL_DIR}/dev" ]]; then
 fi
 ln -s "${ORCH_DIR}/dev" "${INSTALL_DIR}/dev"
 echo "Installed: ${INSTALL_DIR}/dev -> ${ORCH_DIR}/dev"
+
+# ── Install orchestra-status helper (worker idle/busy indicators) ─
+if [[ -f "${ORCH_DIR}/orchestra-status.sh" ]]; then
+  if [[ -L "${INSTALL_DIR}/orchestra-status" || -f "${INSTALL_DIR}/orchestra-status" ]]; then
+    rm -f "${INSTALL_DIR}/orchestra-status"
+  fi
+  ln -s "${ORCH_DIR}/orchestra-status.sh" "${INSTALL_DIR}/orchestra-status"
+  chmod +x "${ORCH_DIR}/orchestra-status.sh"
+  echo "Installed: ${INSTALL_DIR}/orchestra-status -> ${ORCH_DIR}/orchestra-status.sh"
+fi
 
 # Store repo path so 'dev update' can find it later
 orch_conf="${CONFIG_DIR}/orchestra.conf"
@@ -136,6 +147,49 @@ elif command -v ghostty &>/dev/null || [[ -d "/Applications/Ghostty.app" ]]; the
     echo "Ghostty: auto-restore enabled (created $GHOSTTY_CONFIG)"
   else
     echo "Ghostty: skipped (add manually: command = ${INSTALL_DIR}/orchestra-attach)"
+  fi
+fi
+
+# ── Optional: Ghostty Cmd+0-9 keybindings ──────────────────────
+if [[ -f "${ORCH_DIR}/ghostty.example.conf" ]] && (command -v ghostty &>/dev/null || [[ -d "/Applications/Ghostty.app" ]]); then
+  if [[ -f "$GHOSTTY_CONFIG" ]] && grep -q "super+zero=text" "$GHOSTTY_CONFIG" 2>/dev/null; then
+    echo "Ghostty: Cmd+0-9 keybindings already configured (skipping)"
+  else
+    read -p "Enable Ghostty Cmd+0-9 keybindings (switch tmux windows)? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      mkdir -p "$(dirname "$GHOSTTY_CONFIG")"
+      echo "" >> "$GHOSTTY_CONFIG"
+      echo "# Claude Orchestra: Cmd+0-9 → tmux window switching (requires Ctrl+A prefix)" >> "$GHOSTTY_CONFIG"
+      grep -E "^keybind" "${ORCH_DIR}/ghostty.example.conf" >> "$GHOSTTY_CONFIG"
+      echo "Ghostty: Cmd+0-9 keybindings enabled"
+    else
+      echo "Ghostty: keybindings skipped (see ghostty.example.conf to add manually)"
+    fi
+  fi
+fi
+
+# ── Optional: tmux config (Ctrl+A prefix, tab-style status, mouse) ─
+if [[ -f "${ORCH_DIR}/tmux.example.conf" ]]; then
+  if [[ -f "$TMUX_CONFIG" ]] && grep -q "Claude Orchestra" "$TMUX_CONFIG" 2>/dev/null; then
+    echo "tmux: orchestra config already present (skipping)"
+  else
+    read -p "Install orchestra tmux config (Ctrl+A prefix, tab-style status, mouse)? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      if [[ -f "$TMUX_CONFIG" ]]; then
+        cp "$TMUX_CONFIG" "${TMUX_CONFIG}.bak.$(date +%s)"
+        echo "tmux: backed up existing ~/.tmux.conf"
+        echo "" >> "$TMUX_CONFIG"
+        echo "# ── Claude Orchestra config (appended by install.sh) ──" >> "$TMUX_CONFIG"
+        cat "${ORCH_DIR}/tmux.example.conf" >> "$TMUX_CONFIG"
+      else
+        cp "${ORCH_DIR}/tmux.example.conf" "$TMUX_CONFIG"
+      fi
+      tmux source-file "$TMUX_CONFIG" 2>/dev/null && echo "tmux: config installed and reloaded" || echo "tmux: config installed (reload with: tmux source-file ~/.tmux.conf)"
+    else
+      echo "tmux: skipped (see tmux.example.conf to add manually)"
+    fi
   fi
 fi
 

--- a/orchestra-status.sh
+++ b/orchestra-status.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env zsh
+# Orchestra status for tmux status bar
+# Shows active workers with idle/busy indicators
+# Supports: claude, kimi, codex, qwen, gemini
+
+ORCH_SESSION="${ORCHESTRA_SESSION:-devenv}"
+
+if ! tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
+  echo ""
+  exit 0
+fi
+
+# AI process patterns (claude shows version like 1.2.3 in pane_current_command)
+AI_PATTERN="^([0-9]+\.[0-9]+\.[0-9]+|claude|kimi|codex|qwen|gemini|node)$"
+
+# Busy keywords across Claude/Kimi/Codex "thinking" states
+BUSY_PATTERN='(running\)|lculating|rnsfiguring|hinking|cogitating|ondering|esigning|nalyzing|orking|earching|eading.*files|riting.*files|xecuting|ompiling|aked for|esc to interrupt)'
+
+result=""
+windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}|#{pane_current_command}" 2>/dev/null)
+
+while IFS='|' read -r wname pcmd; do
+  [[ -z "$wname" ]] && continue
+  [[ "$wname" == "orchestra" ]] && continue
+  [[ ! "$pcmd" =~ $AI_PATTERN ]] && continue
+
+  output=$(tmux capture-pane -t "$ORCH_SESSION:$wname" -p -S -8 2>/dev/null | \
+    sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\xc2\xa0' | sed 's/[[:cntrl:]]//g')
+
+  if echo "$output" | grep -qiE "$BUSY_PATTERN"; then
+    result+="#[fg=#f9e2af,bold]⚡${wname}#[default] "
+  else
+    result+="#[fg=#a6e3a1]✓${wname}#[default] "
+  fi
+done <<< "$windows"
+
+echo "$result"

--- a/tmux.example.conf
+++ b/tmux.example.conf
@@ -1,0 +1,92 @@
+# Claude Orchestra tmux config
+# Source this from ~/.tmux.conf, or copy its contents.
+#
+# Provides:
+#   - Ctrl+A prefix (matches Cmd+0-9 Ghostty keybindings)
+#   - Mouse support (click tabs to switch windows)
+#   - Tab-style status bar with Catppuccin Mocha theme
+#   - Worker idle/busy indicators on the right (✓ green / ⚡ yellow)
+#   - Powerline-style window separators
+#   - Prefix indicator, live clock, vim-like pane navigation
+
+set -g window-size latest
+
+# ── Prefix: Ctrl+A (replaces default Ctrl+B) ──
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# ── Mouse: click tabs / drag panes ──
+set -g mouse on
+
+# ── Terminal & visual basics ──
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+set -g status-interval 1
+set -g focus-events on
+set -sg escape-time 10
+setw -g monitor-activity on
+set -g visual-activity off
+set -g renumber-windows on
+set -g base-index 0
+setw -g pane-base-index 0
+
+# ── Status bar: Catppuccin Mocha tabs ──
+set -g status on
+set -g status-position bottom
+set -g status-justify left
+set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
+
+# Left: session name badge
+set -g status-left-length 40
+set -g status-left "#[bg=#cba6f7,fg=#1e1e2e,bold]  #S #[bg=#1e1e2e,fg=#cba6f7]#[default] "
+
+# Window list (powerline-separated tabs)
+setw -g window-status-format "#[bg=#1e1e2e,fg=#45475a]#[bg=#313244,fg=#cdd6f4] #I  #W#{?window_zoomed_flag, 󰊓,}#{?window_activity_flag, ●,} #[bg=#1e1e2e,fg=#313244] "
+setw -g window-status-current-format "#[bg=#1e1e2e,fg=#f9e2af]#[bg=#f9e2af,fg=#1e1e2e,bold] #I  #W#{?window_zoomed_flag, 󰊓,} #[bg=#1e1e2e,fg=#f9e2af]"
+setw -g window-status-separator ""
+setw -g window-status-activity-style "bg=#313244,fg=#fab387"
+
+# Right: worker status + prefix + clock + date
+set -g status-right-length 200
+set -g status-right "#(~/.local/bin/orchestra-status)#{?client_prefix,#[bg=#f38ba8#,fg=#1e1e2e#,bold] PREFIX ,}#[bg=#1e1e2e,fg=#45475a]#[bg=#313244,fg=#a6e3a1] %H:%M:%S #[bg=#313244,fg=#45475a]│#[fg=#89b4fa] %d %b "
+
+# ── Pane borders ──
+set -g pane-border-style "fg=#45475a"
+set -g pane-active-border-style "fg=#f9e2af"
+set -g pane-border-lines single
+
+# ── Message / command line styling ──
+set -g message-style "bg=#f9e2af,fg=#1e1e2e,bold"
+set -g message-command-style "bg=#cba6f7,fg=#1e1e2e,bold"
+
+# ── Copy mode (vi-style, copies to macOS clipboard) ──
+setw -g mode-keys vi
+set -g mode-style "bg=#f9e2af,fg=#1e1e2e"
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
+
+# ── Vim-like pane navigation ──
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# ── Pane resize (repeatable with -r) ──
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# ── Better split bindings (open in current path) ──
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# ── New window in current path ──
+bind c new-window -c "#{pane_current_path}"
+
+# ── Reload config ──
+bind r source-file ~/.tmux.conf \; display "  tmux reloaded"


### PR DESCRIPTION
## Summary

Brings back features promised in the README but missing from `install.sh` after recent refactors, plus polishes the default tmux UI.

- **`orchestra-status.sh`** — idle/busy indicator for workers in tmux right status bar (✓ green = idle, ⚡ yellow = busy). Supports claude, kimi, codex, qwen, gemini; expanded busy-keyword set covers more thinking states.
- **`tmux.example.conf`** — Catppuccin Mocha tab-style status bar with powerline separators, Ctrl+A prefix, mouse, vim navigation, pane resize, prefix indicator, live clock, copy-to-clipboard via `pbcopy`.
- **`ghostty.example.conf`** — Cmd+0-9 → tmux window switching keybindings (was deleted in cleanup; restored).
- **`install.sh`** — symlinks orchestra-status helper, optionally appends Ghostty Cmd+0-9 keybindings, optionally appends/installs tmux config (with backup).
- **`dev update`** — re-links orchestra-status on update so existing installs pick up the helper without re-running `install.sh`.

## Why

The README promises: "The installer will ask … Ghostty Cmd+number keybindings … orchestra tmux config (Catppuccin theme, Ctrl+A prefix, status bar, vim navigation)" but the current `install.sh` only asks about auto-restore. This PR makes the README accurate again and brings back the worker status indicator that was a useful UX signal.

## Test plan

- [x] `bash -n install.sh && bash -n dev && bash -n orchestra-status.sh` (syntax)
- [x] Manual run: `orchestra-status` returns colored `✓worker` line for an idle Claude worker
- [x] tmux status bar shows tab-style windows with current highlight + activity dot
- [x] Cmd+0-9 (after Ghostty config reload) switches tmux windows
- [x] Existing `~/.tmux.conf` is backed up before append
- [ ] Fresh-install path on a clean machine