### PR TITLE
fix(dev): zsh-compatible prompt + bump ORCHESTRA_VERSION

### DIFF
--- a/dev
+++ b/dev
@@ -12,7 +12,7 @@ if ! command -v tmux &>/dev/null; then
   exit 1
 fi
 
-ORCHESTRA_VERSION="v1.3.2"
+ORCHESTRA_VERSION="v1.4.1"
 ORCHESTRA_REPO_URL="https://github.com/alperduzgun/claude-orchestra"
 
 # Config
@@ -269,7 +269,7 @@ _update() {
   [[ -f "${HOME}/.tmux.conf" ]] && echo "  ~/.tmux.conf"
   echo ""
 
-  read -p "Proceed? (y/N) " -n 1 -r; echo ""
+  read -k 1 "REPLY?Proceed? (y/N) "; echo ""
   [[ ! "$REPLY" =~ ^[Yy]$ ]] && { echo "Cancelled."; return 0; }
 
   echo ""


### PR DESCRIPTION
## Bug

\`dev update\` crashes with:

\`\`\`
_update:read:72: -p: no coprocess
Cancelled.
\`\`\`

\`read -p\` is bash syntax. The dev script's shebang is \`zsh\`, where \`-p\` means "read from a coprocess" — and there is none, so the read aborts.

Also: \`ORCHESTRA_VERSION\` was stuck at \`v1.3.2\` through v1.3.x and v1.4.0, so \`dev update\` always reported the wrong "Current" value.

## Fix

- \`read -p \"…\" -n 1 -r\` → \`read -k 1 \"REPLY?…\"\` (zsh-native)
- \`ORCHESTRA_VERSION\` bump: \`v1.3.2\` → \`v1.4.1\`

## Test plan

- [x] \`zsh -n dev\` syntax check
- [ ] Live: \`dev update\` reaches the confirm prompt and accepts \`y\`