### PR TITLE
feat: ORCHESTRA_NOTIFY env var to silence desktop notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Environment variables (set in your shell profile):
 | `MAX_AI_SESSIONS` | `3` | Max concurrent AI sessions across Claude, Kimi, and Codex workers |
 | `CLAUDE_BIN` | auto-detected | Path to Claude Code binary |
 | `KIMI_BIN` | auto-detected | Path to Kimi CLI binary |
+| `ORCHESTRA_NOTIFY` | `1` | Set to `0`/`false`/`no`/`off` to silence desktop notifications fired by `dev wait`, `dev ask`, `dev run`, and `dev recover` |
 
 > **Note:** `ORCHESTRA_DIR` and `ORCHESTRA_CONFIG_DIR` now default to different paths. `ORCHESTRA_DIR` controls where the orchestrator AI runs and reads its dedicated prompt files. `ORCHESTRA_CONFIG_DIR` controls where the project registry, worker-safe root instructions, and shared config files live.
 

--- a/dev
+++ b/dev
@@ -12,7 +12,7 @@ if ! command -v tmux &>/dev/null; then
   exit 1
 fi
 
-ORCHESTRA_VERSION="v1.4.1"
+ORCHESTRA_VERSION="v1.4.2"
 ORCHESTRA_REPO_URL="https://github.com/alperduzgun/claude-orchestra"
 
 # Config
@@ -74,7 +74,11 @@ _log_history() {
 }
 
 # Desktop notification helper (macOS + Linux)
+# Silenced when ORCHESTRA_NOTIFY ∈ {0, false, no, off} (case-insensitive)
 _notify() {
+  case "${ORCHESTRA_NOTIFY:-1}" in
+    0|false|False|FALSE|no|No|NO|off|Off|OFF) return 0 ;;
+  esac
   local title="${1:-Orchestra}"
   local msg="${2:-Task complete}"
   if command -v osascript &>/dev/null; then


### PR DESCRIPTION
## Why

The orchestrator prompts instruct the AI to call \`dev wait\` after every \`dev send\`. \`dev wait\` (and \`dev ask\`/\`dev run\`/\`dev recover\`) fire \`osascript\`/\`notify-send\` desktop notifications on every completion. When the orchestrator is driving multiple worker round-trips, the user gets a flood of "Task complete" notifications in macOS Notification Center.

Confirmed by user with screenshot: repeated "toptantr-flutter / Task complete (58s)" banners.

## Fix

\`_notify\` now checks \`ORCHESTRA_NOTIFY\`. When set to \`0\`/\`false\`/\`no\`/\`off\` (case-insensitive), it returns immediately without calling \`osascript\`/\`notify-send\`.

Default stays \`1\` for backward compatibility — users who rely on the notification when running \`dev wait\` from a side terminal keep the current behavior. Users driving everything through the orchestrator can \`export ORCHESTRA_NOTIFY=0\` to silence.

Bumps \`ORCHESTRA_VERSION\` to v1.4.2.

## Test plan

- [x] \`zsh -n dev\` syntax check
- [x] \`ORCHESTRA_NOTIFY=0 dev notify Test "should not appear"\` — no banner
- [x] \`dev notify Test "should appear"\` — banner appears (default behavior preserved)