### PR TITLE
feat: add opencode and gemini AI worker support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,17 @@
+# Orchestra Repo Gemini Worker
+
+This repo-root `GEMINI.md` is intentionally worker-oriented so Gemini sessions started in `~/.config/orchestra` do not inherit orchestrator-role rules.
+
+## Role
+
+You are a worker AI editing the orchestra repo. Read [WORKER.md](WORKER.md) before acting, then follow the local task.
+
+## Repo-Specific Notes
+
+- The dedicated orchestrator prompt files live under [orchestrator/](orchestrator).
+- The repo root contains worker-safe instructions only.
+- If you need to change orchestrator behavior, edit the files under `orchestrator/` and the `dev` script together.
+
+## Output
+
+Be concise. Report actions taken. End completion replies with `DONE: <one-line summary>`.

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,0 +1,17 @@
+# Orchestra Repo OpenCode Worker
+
+This repo-root `OPENCODE.md` is intentionally worker-oriented so OpenCode sessions started in `~/.config/orchestra` do not inherit orchestrator-role rules.
+
+## Role
+
+You are a worker AI editing the orchestra repo. Read [WORKER.md](WORKER.md) before acting, then follow the local task.
+
+## Repo-Specific Notes
+
+- The dedicated orchestrator prompt files live under [orchestrator/](orchestrator).
+- The repo root contains worker-safe instructions only.
+- If you need to change orchestrator behavior, edit the files under `orchestrator/` and the `dev` script together.
+
+## Output
+
+Be concise. Report actions taken. End completion replies with `DONE: <one-line summary>`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Manage multiple Claude Code, Kimi CLI, and Forge Code sessions from a single terminal.</strong><br>
+  <strong>Manage multiple Claude Code, Kimi CLI, Forge Code, Gemini CLI, and OpenCode sessions from a single terminal.</strong><br>
   One orchestrator AI controls worker AI sessions across your projects via tmux.
 </p>
 
@@ -23,9 +23,9 @@ Two prompts below — one for **fresh install**, one for **update**. Copy-paste 
 ### Install prompt
 
 ```
-Install Claude Orchestra — a tmux-based multi-agent AI orchestrator for Claude Code, Kimi CLI, and Forge Code.
+Install Claude Orchestra — a tmux-based multi-agent AI orchestrator for Claude Code, Kimi CLI, Forge Code, Gemini CLI, and OpenCode.
 
-Prerequisites: tmux 3.0+, zsh, Claude Code (https://docs.anthropic.com/en/docs/claude-code) OR Kimi CLI (https://github.com/moonshot-ai/kimi-cli) OR Forge Code (https://github.com/tailcallhq/forgecode)
+Prerequisites: tmux 3.0+, zsh, Claude Code (https://docs.anthropic.com/en/docs/claude-code) OR Kimi CLI (https://github.com/moonshot-ai/kimi-cli) OR Forge Code (https://github.com/tailcallhq/forgecode) OR Gemini CLI (https://ai.google.dev/gemini-cli/docs) OR OpenCode
 Recommended: Ghostty terminal (https://ghostty.org/) for auto-restore and Cmd+number window switching
 
 Steps:

--- a/README.md
+++ b/README.md
@@ -85,16 +85,28 @@ Ghostty / Terminal
 - `dev` → Claude orchestrator (default)
 - `dev kimi` → Kimi orchestrator
 - `dev forge` → Forge orchestrator
+- `dev codex` → Codex orchestrator
+- `dev gemini` → Gemini orchestrator
+- `dev opencode` → OpenCode orchestrator
 
 **Worker Options:**
-- `dev start <project>` → Start Claude worker
+- `dev start <project>` → Start Claude worker (default)
+- `dev start <project> --dual <left> <right>` → Start dual AI workers
 - `dev kimi start <project>` → Start Kimi worker
 - `dev forge start <project>` → Start Forge worker
+- `dev codex start <project>` → Start Codex worker
+- `dev gemini start <project>` → Start Gemini worker
+- `dev opencode start <project>` → Start OpenCode worker
+
+Dual mode examples:
+- `dev start myapp --dual claude codex` → Claude + Codex
+- `dev start myapp --dual claude opencode` → Claude + OpenCode
+- `dev start myapp --dual kimi gemini` → Kimi + Gemini
 
 - You tell the orchestrator what to do across projects
 - It starts worker sessions and assigns tasks
 - Switch to any window with `Ctrl+A <number>` for manual control
-- Max 3 concurrent AI sessions (Claude + Kimi + Codex + Forge combined, configurable, RAM-dependent)
+- Max 3 concurrent AI sessions (Claude + Kimi + Codex + Forge + opencode + gemini combined, configurable, RAM-dependent)
 - Close Ghostty and reopen — session resumes where you left off
 - Mix and match: Claude orchestrator can control Kimi/Forge workers and vice versa!
 
@@ -120,7 +132,13 @@ Workers have zero context about your conversation. The orchestrator bridges this
 - macOS or Linux
 - [tmux](https://github.com/tmux/tmux) 3.0+
 - [zsh](https://www.zsh.org/)
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) AND/OR [Kimi CLI](https://github.com/moonshot-ai/kimi-cli) AND/OR [Forge Code](https://github.com/tailcallhq/forgecode)
+- One or more AI tools:
+  - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+  - [Kimi CLI](https://github.com/moonshot-ai/kimi-cli)
+  - [Forge Code](https://github.com/tailcallhq/forgecode)
+  - [Codex CLI](https://openai.com/index/codex/)
+  - [Gemini CLI](https://ai.google.dev/gemini-cli/docs)
+  - [OpenCode](https://opencode.ai)
 - [Ghostty](https://ghostty.org/) (recommended, for auto-restore)
 
 ## Install
@@ -176,10 +194,14 @@ dev forge                # Start Forge as orchestrator
 # It runs: dev start myapp && dev start backend (or dev kimi start ... or dev forge start ...)
 
 # Or manually:
-dev start myapp          # Start Claude for a project
-dev kimi start myapp     # Start Kimi for a project
-dev forge start myapp    # Start Forge for a project
-dev send myapp "fix X"   # Send a task (auto-detects Claude/Kimi)
+dev start myapp          # Start Claude worker (default)
+dev start myapp --dual claude opencode  # Claude + OpenCode dual
+dev kimi start myapp     # Start Kimi worker
+dev forge start myapp    # Start Forge worker
+dev codex start myapp    # Start Codex worker
+dev gemini start myapp   # Start Gemini worker
+dev opencode start myapp  # Start OpenCode worker
+dev send myapp "fix X"   # Send a task (auto-detects AI type)
 dev broadcast "run tests" # Send to all active AI sessions
 dev status               # See what's running
 dev kill myapp           # Stop a project session
@@ -239,12 +261,14 @@ Environment variables (set in your shell profile):
 | `ORCHESTRA_SESSION` | `devenv` | tmux session name |
 | `ORCHESTRA_DIR` | `~/.config/orchestra/orchestrator` | Dedicated orchestrator prompt directory and working directory for window 0 |
 | `ORCHESTRA_CONFIG_DIR` | `~/.config/orchestra` | Where `projects.conf` lives (can differ from `ORCHESTRA_DIR`) |
-| `ORCHESTRA_AI` | `claude` | Orchestrator AI type: `claude`, `kimi`, or `forge` |
-| `MAX_AI_SESSIONS` | `3` | Max concurrent AI sessions across Claude, Kimi, Codex, and Forge workers |
+| `ORCHESTRA_AI` | `claude` | Orchestrator AI type: `claude`, `kimi`, `forge`, `codex`, `gemini`, or `opencode` |
+| `MAX_AI_SESSIONS` | `3` | Max concurrent AI sessions across all worker types |
 | `CLAUDE_BIN` | auto-detected | Path to Claude Code binary |
 | `KIMI_BIN` | auto-detected | Path to Kimi CLI binary |
 | `CODEX_BIN` | auto-detected | Path to Codex CLI binary |
 | `FORGE_BIN` | auto-detected | Path to Forge Code binary |
+| `GEMINI_BIN` | auto-detected | Path to Gemini CLI binary |
+| `OPENCODE_BIN` | auto-detected | Path to OpenCode binary |
 | `ORCHESTRA_NOTIFY` | `1` | Set to `0`/`false`/`no`/`off` to silence desktop notifications fired by `dev wait`, `dev ask`, `dev run`, and `dev recover` |
 
 > **Note:** `ORCHESTRA_DIR` and `ORCHESTRA_CONFIG_DIR` now default to different paths. `ORCHESTRA_DIR` controls where the orchestrator AI runs and reads its dedicated prompt files. `ORCHESTRA_CONFIG_DIR` controls where the project registry, worker-safe root instructions, and shared config files live.
@@ -256,17 +280,26 @@ Environment variables (set in your shell profile):
 | `dev` / `dev o` / `dev orch` / `dev orchestra` | Start the orchestrator (default: Claude) |
 | `ORCHESTRA_AI=kimi dev` | Start Kimi orchestrator |
 | `ORCHESTRA_AI=forge dev` | Start Forge orchestrator |
-| `dev start <project>` | Start Claude in a tmux window |
-| `dev kimi start <project>` | Start Kimi in a tmux window |
-| `dev forge start <project>` | Start Forge in a tmux window |
-| `dev send <project> "msg"` | Send message to a project's AI (auto-detects Claude/Kimi/Forge) |
+| `ORCHESTRA_AI=codex dev` | Start Codex orchestrator |
+| `ORCHESTRA_AI=gemini dev` | Start Gemini orchestrator |
+| `ORCHESTRA_AI=opencode dev` | Start OpenCode orchestrator |
+| `dev start <project>` | Start Claude worker (default) |
+| `dev start <project> --dual <left> <right>` | Start dual AI workers |
+| `dev kimi start <project>` | Start Kimi worker |
+| `dev forge start <project>` | Start Forge worker |
+| `dev codex start <project>` | Start Codex worker |
+| `dev gemini start <project>` | Start Gemini worker |
+| `dev opencode start <project>` | Start OpenCode worker |
+| `dev send <project> "msg"` | Send message to a project's AI |
+| `dev send <project> --opencode "msg"` | Send to opencode worker (dual mode) |
+| `dev send <project> --gemini "msg"` | Send to gemini worker (dual mode) |
 | `dev peek <project> [lines]` | Read worker's recent output (default: 50 lines) |
 | `dev watch <project>` | Live tail of worker's log |
 | `dev done <project>` | Check if worker is idle or working |
 | `dev wait <project> [sec]` | Wait for worker to finish, then notify (default: 300s) |
 | `dev ask <project> "msg"` | Send question, wait for response (timeout: 120s) |
 | `dev run <project> "task"` | Non-interactive task (claude --print) |
-| `dev broadcast "msg"` | Send to all active AI sessions (Claude + Kimi + Codex + Forge) |
+| `dev broadcast "msg"` | Send to all active AI sessions |
 | `dev history [alias] [n]` | Show recent task history (default: 30 lines) |
 | `dev recover <project>` | Recover crashed session |
 | `dev recover --all` | Recover all crashed sessions |
@@ -282,14 +315,14 @@ Environment variables (set in your shell profile):
 
 ## Safety
 
-- `dev send` only delivers to windows running AI (Claude, Kimi, Codex, or Forge) — never to a bare shell
+- `dev send` only delivers to windows running AI workers — never to a bare shell
 - `dev broadcast` skips non-AI windows automatically
 - Session limit is enforced in the script (not just documentation)
 - AI readiness is verified before sending (polls for process, max 15s)
 - Messages >1000 chars use tmux buffer (avoids PTY silent truncation at 1024 bytes)
 - Installer never overwrites existing configs — asks before modifying
 - Alias names validated (alphanumeric, hyphens, underscores only)
-- `CLAUDE_BIN`, `KIMI_BIN`, `CODEX_BIN`, and `FORGE_BIN` quoted in all tmux commands (injection prevention)
+- All AI binary paths quoted in all tmux commands (injection prevention)
 - Notifications use safe argv passthrough (no shell interpolation)
 - AI type is tracked per window for proper recovery
 

--- a/dev
+++ b/dev
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
-# Dev - Project launcher & Claude Code / Kimi CLI / Forge Code orchestrator
+# Dev - Project launcher & Claude Code / Kimi CLI / Forge Code / opencode orchestrator
 # Usage: dev <project> | dev list | dev start <project> | dev send <project> "msg"
-# Requires: zsh, tmux, Claude Code (https://docs.anthropic.com/en/docs/claude-code) or Kimi CLI (https://github.com/moonshot-ai/kimi-cli) or Forge Code (https://github.com/tailcallhq/forgecode)
+# Requires: zsh, tmux, Claude Code (https://docs.anthropic.com/en/docs/claude-code) or Kimi CLI (https://github.com/moonshot-ai/kimi-cli) or Forge Code (https://github.com/tailcallhq/forgecode) or opencode (https://opencode.ai)
 
 # Clear nested Claude Code detection
 unset CLAUDECODE
@@ -22,6 +22,7 @@ CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo "$HOME/.local/
 KIMI_BIN="${KIMI_BIN:-$(command -v kimi 2>/dev/null || echo "$HOME/.local/bin/kimi")}"
 CODEX_BIN="${CODEX_BIN:-$(command -v codex 2>/dev/null || echo "$HOME/.local/bin/codex")}"
 FORGE_BIN="${FORGE_BIN:-$(command -v forge 2>/dev/null || echo "$HOME/.local/bin/forge")}"
+OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "$HOME/.local/bin/opencode")}"
 
 # AI window tracking file (stores which AI is running in each window)
 AI_TRACK_FILE="$CONFIG_DIR/.ai_windows"
@@ -61,6 +62,15 @@ _require_forge() {
     return 1
   fi
 }
+
+# Validate OPENCODE_BIN
+_require_opencode() {
+  if [[ ! -x "$OPENCODE_BIN" ]]; then
+    echo "ERROR: opencode binary not found or not executable: $OPENCODE_BIN"
+    echo "Install opencode: https://opencode.ai"
+    return 1
+  fi
+}
 ORCH_SESSION="${ORCHESTRA_SESSION:-devenv}"
 # ORCH_DIR: dedicated orchestrator prompt directory
 # Override with ORCHESTRA_DIR env var or set in ~/.config/orchestra/orchestra.conf
@@ -76,6 +86,8 @@ KIMI_PROC_PATTERN="(kimi|python.*kimi)"
 CODEX_PROC_PATTERN="^node$"
 # Forge Code is a native binary
 FORGE_PROC_PATTERN="^forge$"
+# opencode is a native binary
+OPENCODE_PROC_PATTERN="^opencode$"
 LOG_DIR="${HOME}/.local/share/orchestra/logs"
 HISTORY_FILE="${HOME}/.local/share/orchestra/history.log"
 
@@ -470,6 +482,8 @@ _detect_ai_type() {
     echo "codex"
   elif [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
     echo "forge"
+  elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+    echo "opencode"
   else
     echo ""
   fi
@@ -483,6 +497,7 @@ _is_ai_running() {
   if [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then return 0; fi
   if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then return 0; fi
   if [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then return 0; fi
+  if [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then return 0; fi
   return 1
 }
 
@@ -493,12 +508,13 @@ _get_ai_bin() {
     kimi) echo "$KIMI_BIN" ;;
     codex) echo "$CODEX_BIN" ;;
     forge) echo "$FORGE_BIN" ;;
+    opencode) echo "$OPENCODE_BIN" ;;
     *) echo "" ;;
   esac
 }
 
 # Return the shell command that launches a given AI tool.
-# Supported: claude, codex, kimi, forge, qwen, gemini
+# Supported: claude, codex, kimi, forge, qwen, gemini, opencode
 _ai_launch_cmd() {
   local ai="$1"
   case "$ai" in
@@ -508,6 +524,7 @@ _ai_launch_cmd() {
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "gemini" ;;
+    opencode) echo "'$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
 }
@@ -522,7 +539,8 @@ _ai_require() {
     forge)  command -v forge  >/dev/null || { echo "ERROR: forge not found in PATH"; return 1; } ;;
     qwen)   command -v qwen   >/dev/null || { echo "ERROR: qwen not found in PATH"; return 1; } ;;
     gemini) command -v gemini >/dev/null || { echo "ERROR: gemini not found in PATH"; return 1; } ;;
-    *)      echo "ERROR: unknown AI type: $ai (supported: claude, codex, kimi, forge, qwen, gemini)"; return 1 ;;
+    opencode) _require_opencode ;;
+    *)      echo "ERROR: unknown AI type: $ai (supported: claude, codex, kimi, forge, qwen, gemini, opencode)"; return 1 ;;
   esac
 }
 
@@ -533,6 +551,7 @@ _orchestrator_required_reading() {
     codex)  echo "AGENTS.md, CODEX.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     kimi)   echo "AGENTS.md, KIMI.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     forge)  echo "AGENTS.md, FORGE.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
+    opencode) echo "AGENTS.md, OPENCODE.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     *) return 1 ;;
   esac
 }
@@ -558,6 +577,7 @@ _worker_launch_cmd() {
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "gemini" ;;
+    opencode) echo "'$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
 }
@@ -743,6 +763,7 @@ _detect_pane_ai() {
   elif [[ "$pcmd" == "forge" ]]; then echo "forge"
   elif [[ "$pcmd" == "qwen" ]]; then echo "qwen"
   elif [[ "$pcmd" == "gemini" ]]; then echo "gemini"
+  elif [[ "$pcmd" == "opencode" ]]; then echo "opencode"
   else echo "$pcmd"
   fi
 }
@@ -762,6 +783,7 @@ _is_done() {
   [[ "$pane_cmd" =~ ^[Pp]ython ]] && is_ai=true
   [[ "$pane_cmd" == "kimi" ]] && is_ai=true
   [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]] && is_ai=true
+  [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]] && is_ai=true
   [[ "$is_ai" == false ]] && return 2
 
   # NOTE: Forge state detection is best-effort. Forge TUI idle/active
@@ -891,6 +913,8 @@ _list() {
         sess_state="[kimi]"
       elif [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
         sess_state="[forge]"
+      elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+        sess_state="[opencode]"
       else
         sess_state="[shell]"
       fi
@@ -980,7 +1004,7 @@ _start() {
 
   if [[ -z "$name" ]]; then
     echo "Usage: dev start <project> [--dual [left_ai] [right_ai]]"
-    echo "  Supported AI types: claude, codex, kimi, forge, qwen, gemini"
+    echo "  Supported AI types: claude, codex, kimi, forge, qwen, gemini, opencode"
     echo "  Default dual: claude + codex"
     return 1
   fi
@@ -1091,8 +1115,8 @@ _start_dual() {
 
   # Resolve launch commands and verify binaries
   local left_cmd right_cmd
-  left_cmd=$(_worker_launch_cmd "$left_ai")  || { echo "ERROR: unknown left AI '$left_ai' (supported: claude, codex, kimi, forge, qwen, gemini)"; return 1; }
-  right_cmd=$(_worker_launch_cmd "$right_ai") || { echo "ERROR: unknown right AI '$right_ai' (supported: claude, codex, kimi, forge, qwen, gemini)"; return 1; }
+  left_cmd=$(_worker_launch_cmd "$left_ai")  || { echo "ERROR: unknown left AI '$left_ai' (supported: claude, codex, kimi, forge, qwen, gemini, opencode)"; return 1; }
+  right_cmd=$(_worker_launch_cmd "$right_ai") || { echo "ERROR: unknown right AI '$right_ai' (supported: claude, codex, kimi, forge, qwen, gemini, opencode)"; return 1; }
   _ai_require "$left_ai"  || return 1
   _ai_require "$right_ai" || return 1
   _ensure_session || return 1
@@ -1373,9 +1397,9 @@ _send() {
   local target="left"
   local msg_parts=()
 
-  # Parse: dev send <project> [--qwen|--right|--left] <message>
+  # Parse: dev send <project> [--qwen|--right|--left|--opencode] <message>
   for arg in "$@"; do
-    if [[ "$arg" == "--qwen" || "$arg" == "--right" ]]; then
+    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" ]]; then
       target="right"
     elif [[ "$arg" == "--left" ]]; then
       target="left"
@@ -1468,6 +1492,8 @@ _status() {
         sess_state="codex"
       elif [[ "$pcmd" =~ $FORGE_PROC_PATTERN ]]; then
         sess_state="forge"
+      elif [[ "$pcmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+        sess_state="opencode"
       fi
       printf "  %-4s %-18s %-12s %s\n" "$idx" "$wname" "[$sess_state]" "${dir/$HOME/~}"
     done <<< "$windows"
@@ -1495,6 +1521,7 @@ _broadcast() {
   local kimi_count=0
   local codex_count=0
   local forge_count=0
+  local opencode_count=0
   local skipped=0
   if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
     local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null)
@@ -1514,6 +1541,9 @@ _broadcast() {
       elif [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
         is_ai=true
         forge_count=$((forge_count + 1))
+      elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+        is_ai=true
+        opencode_count=$((opencode_count + 1))
       fi
       
       if [[ "$is_ai" == true ]]; then
@@ -1524,8 +1554,8 @@ _broadcast() {
       fi
     done <<< "$windows"
   fi
-  local total=$((claude_count + kimi_count + codex_count + forge_count))
-  echo "Broadcast to $total AI sessions (Claude: $claude_count, Kimi: $kimi_count, Codex: $codex_count, Forge: $forge_count, skipped: $skipped)."
+  local total=$((claude_count + kimi_count + codex_count + forge_count + opencode_count))
+  echo "Broadcast to $total AI sessions (Claude: $claude_count, Kimi: $kimi_count, Codex: $codex_count, Forge: $forge_count, opencode: $opencode_count, skipped: $skipped)."
 }
 
 # Peek at a worker's recent output
@@ -1537,7 +1567,7 @@ _peek() {
   local raw=false
 
   for arg in "$@"; do
-    if [[ "$arg" == "--qwen" || "$arg" == "--right" ]]; then
+    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" ]]; then
       target="right"
     elif [[ "$arg" == "--left" ]]; then
       target="left"
@@ -1555,7 +1585,7 @@ _peek() {
   done
 
   if [[ -z "$name" ]]; then
-    echo "Usage: dev peek <project> [--qwen|--right|--left] [--screen] [--raw] [lines]"
+    echo "Usage: dev peek <project> [--qwen|--right|--left|--opencode] [--screen] [--raw] [lines]"
     return 1
   fi
 
@@ -1798,7 +1828,7 @@ _recover() {
         [[ -z "${PROJECTS[$wname]}" ]] && continue
         
         # Check current AI type and recover accordingly
-        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]] && [[ ! "$pcmd" =~ $CODEX_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $FORGE_PROC_PATTERN ]]; then
+        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]] && [[ ! "$pcmd" =~ $CODEX_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $FORGE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $OPENCODE_PROC_PATTERN ]]; then
           # Window exists but no AI running - determine which AI was there
           local tracked_ai=$(_get_ai_type "$wname")
           local dir="${PROJECTS[$wname]}"
@@ -1984,6 +2014,8 @@ _orchestra() {
     current_ai="codex"
   elif [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
     current_ai="forge"
+  elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+    current_ai="opencode"
   fi
 
   # If a different AI is running, kill it first
@@ -2146,15 +2178,16 @@ case "$1" in
     echo "  dev kimi                   Start Kimi orchestrator"
     echo "  dev codex                  Start Codex orchestrator"
     echo "  dev forge                  Start Forge orchestrator"
+    echo "  dev opencode               Start opencode orchestrator"
     echo "  dev orchestra              Start orchestrator (master session)"
     echo "  dev start <project>        Start Claude in a window (max $MAX_AI_SESSIONS total)"
     echo "  dev start <p> --dual [L] [R]  Dual pane, any AI combo (default: claude codex)"
-    echo "                               L/R ∈ {claude, codex, kimi, forge, qwen, gemini}"
+    echo "                               L/R ∈ {claude, codex, kimi, forge, qwen, gemini, opencode}"
     echo "  dev kimi start <project>   Start Kimi in a window"
     echo "  dev codex start <project>  Start Codex in a window"
     echo "  dev forge start <project>  Start Forge in a window"
-    echo "  dev send <p> [--right|--qwen|--left] <msg>   Send message (right pane in dual)"
-    echo "  dev peek <p> [--right|--qwen|--left] [lines] Read output (right pane in dual)"
+    echo "  dev send <p> [--right|--qwen|--left|--opencode] <msg>   Send message (right pane in dual)"
+    echo "  dev peek <p> [--right|--qwen|--left|--opencode] [lines] Read output (right pane in dual)"
     echo "  dev broadcast <msg>        Send to all active AI sessions"
     echo "  dev status                 Show all windows and their status"
     echo "  dev list                   List all projects"

--- a/dev
+++ b/dev
@@ -596,7 +596,7 @@ _worker_launch_cmd() {
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "'$GEMINI_BIN'" ;;
-    opencode) echo "'$OPENCODE_BIN' --prompt '$prompt'" ;;
+    opencode) echo "'$OPENCODE_BIN' --prompt '$prompt' --dangerously-skip-permissions" ;;
     *)      return 1 ;;
   esac
 }
@@ -666,9 +666,6 @@ _send_worker_bootstrap_if_needed() {
         sleep 1
         waited=$((waited + 1))
       done
-      sleep 1
-      tmux send-keys -t "$target" -l "$prompt"
-      tmux send-keys -t "$target" Enter
       ;;
     gemini)
       local max_wait=15

--- a/dev
+++ b/dev
@@ -23,6 +23,7 @@ KIMI_BIN="${KIMI_BIN:-$(command -v kimi 2>/dev/null || echo "$HOME/.local/bin/ki
 CODEX_BIN="${CODEX_BIN:-$(command -v codex 2>/dev/null || echo "$HOME/.local/bin/codex")}"
 FORGE_BIN="${FORGE_BIN:-$(command -v forge 2>/dev/null || echo "$HOME/.local/bin/forge")}"
 OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "$HOME/.local/bin/opencode")}"
+GEMINI_BIN="${GEMINI_BIN:-$(command -v gemini 2>/dev/null || echo "$HOME/.local/bin/gemini")}"
 
 # AI window tracking file (stores which AI is running in each window)
 AI_TRACK_FILE="$CONFIG_DIR/.ai_windows"
@@ -71,6 +72,15 @@ _require_opencode() {
     return 1
   fi
 }
+
+# Validate GEMINI_BIN
+_require_gemini() {
+  if [[ ! -x "$GEMINI_BIN" ]]; then
+    echo "ERROR: gemini binary not found or not executable: $GEMINI_BIN"
+    echo "Install Gemini CLI: https://ai.google.dev/gemini-cli/docs"
+    return 1
+  fi
+}
 ORCH_SESSION="${ORCHESTRA_SESSION:-devenv}"
 # ORCH_DIR: dedicated orchestrator prompt directory
 # Override with ORCHESTRA_DIR env var or set in ~/.config/orchestra/orchestra.conf
@@ -88,6 +98,10 @@ CODEX_PROC_PATTERN="^node$"
 FORGE_PROC_PATTERN="^forge$"
 # opencode is a native binary
 OPENCODE_PROC_PATTERN="^opencode$"
+# Gemini CLI is a Node.js app (runs as 'node' with gemini arg)
+GEMINI_PROC_PATTERN="gemini"
+# But we need to distinguish from codex - check the full command
+GEMINI_FULL_PROC_PATTERN="node.*gemini"
 LOG_DIR="${HOME}/.local/share/orchestra/logs"
 HISTORY_FILE="${HOME}/.local/share/orchestra/history.log"
 
@@ -484,6 +498,8 @@ _detect_ai_type() {
     echo "forge"
   elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
     echo "opencode"
+  elif [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+    echo "gemini"
   else
     echo ""
   fi
@@ -498,6 +514,7 @@ _is_ai_running() {
   if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then return 0; fi
   if [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then return 0; fi
   if [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then return 0; fi
+  if [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then return 0; fi
   return 1
 }
 
@@ -509,6 +526,7 @@ _get_ai_bin() {
     codex) echo "$CODEX_BIN" ;;
     forge) echo "$FORGE_BIN" ;;
     opencode) echo "$OPENCODE_BIN" ;;
+    gemini) echo "$GEMINI_BIN" ;;
     *) echo "" ;;
   esac
 }
@@ -523,7 +541,7 @@ _ai_launch_cmd() {
     codex)  echo "'$CODEX_BIN'" ;;
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
-    gemini) echo "gemini" ;;
+    gemini) echo "'$GEMINI_BIN' --skip-trust" ;;
     opencode) echo "'$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
@@ -538,7 +556,7 @@ _ai_require() {
     codex)  command -v codex  >/dev/null || { echo "ERROR: codex not found in PATH"; return 1; } ;;
     forge)  command -v forge  >/dev/null || { echo "ERROR: forge not found in PATH"; return 1; } ;;
     qwen)   command -v qwen   >/dev/null || { echo "ERROR: qwen not found in PATH"; return 1; } ;;
-    gemini) command -v gemini >/dev/null || { echo "ERROR: gemini not found in PATH"; return 1; } ;;
+    gemini) _require_gemini ;;
     opencode) _require_opencode ;;
     *)      echo "ERROR: unknown AI type: $ai (supported: claude, codex, kimi, forge, qwen, gemini, opencode)"; return 1 ;;
   esac
@@ -552,6 +570,7 @@ _orchestrator_required_reading() {
     kimi)   echo "AGENTS.md, KIMI.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     forge)  echo "AGENTS.md, FORGE.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     opencode) echo "AGENTS.md, OPENCODE.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
+    gemini) echo "AGENTS.md, GEMINI.md, ORCHESTRATOR.md, MODEL-SELECTION.md, and TROUBLESHOOTING.md" ;;
     *) return 1 ;;
   esac
 }
@@ -576,8 +595,8 @@ _worker_launch_cmd() {
     kimi)   echo "'$KIMI_BIN'" ;;
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
-    gemini) echo "gemini" ;;
-    opencode) echo "'$OPENCODE_BIN'" ;;
+    gemini) echo "'$GEMINI_BIN' -p '$prompt'" ;;
+    opencode) echo "'$OPENCODE_BIN' --prompt '$prompt'" ;;
     *)      return 1 ;;
   esac
 }
@@ -626,6 +645,38 @@ _send_worker_bootstrap_if_needed() {
         local pane_cmd
         pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
         if [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
+          break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+      done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
+      ;;
+    opencode)
+      local max_wait=15
+      local waited=0
+      while [[ $waited -lt $max_wait ]]; do
+        local pane_cmd
+        pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
+        if [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+          break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+      done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
+      ;;
+    gemini)
+      local max_wait=15
+      local waited=0
+      while [[ $waited -lt $max_wait ]]; do
+        local pane_cmd
+        pane_cmd=$(tmux display-message -p -t "$target" "#{pane_current_command}" 2>/dev/null)
+        if [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
           break
         fi
         sleep 1
@@ -762,7 +813,7 @@ _detect_pane_ai() {
   elif [[ "$pcmd" == "codex" ]]; then echo "codex"
   elif [[ "$pcmd" == "forge" ]]; then echo "forge"
   elif [[ "$pcmd" == "qwen" ]]; then echo "qwen"
-  elif [[ "$pcmd" == "gemini" ]]; then echo "gemini"
+  elif [[ "$pcmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pcmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then echo "gemini"
   elif [[ "$pcmd" == "opencode" ]]; then echo "opencode"
   else echo "$pcmd"
   fi
@@ -784,6 +835,7 @@ _is_done() {
   [[ "$pane_cmd" == "kimi" ]] && is_ai=true
   [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]] && is_ai=true
   [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]] && is_ai=true
+  [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]] && is_ai=true
   [[ "$is_ai" == false ]] && return 2
 
   # NOTE: Forge state detection is best-effort. Forge TUI idle/active
@@ -915,6 +967,8 @@ _list() {
         sess_state="[forge]"
       elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
         sess_state="[opencode]"
+      elif [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+        sess_state="[gemini]"
       else
         sess_state="[shell]"
       fi
@@ -1399,7 +1453,7 @@ _send() {
 
   # Parse: dev send <project> [--qwen|--right|--left|--opencode] <message>
   for arg in "$@"; do
-    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" ]]; then
+    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" || "$arg" == "--gemini" ]]; then
       target="right"
     elif [[ "$arg" == "--left" ]]; then
       target="left"
@@ -1494,6 +1548,8 @@ _status() {
         sess_state="forge"
       elif [[ "$pcmd" =~ $OPENCODE_PROC_PATTERN ]]; then
         sess_state="opencode"
+      elif [[ "$pcmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pcmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+        sess_state="gemini"
       fi
       printf "  %-4s %-18s %-12s %s\n" "$idx" "$wname" "[$sess_state]" "${dir/$HOME/~}"
     done <<< "$windows"
@@ -1522,6 +1578,7 @@ _broadcast() {
   local codex_count=0
   local forge_count=0
   local opencode_count=0
+  local gemini_count=0
   local skipped=0
   if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
     local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}" 2>/dev/null)
@@ -1544,6 +1601,9 @@ _broadcast() {
       elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
         is_ai=true
         opencode_count=$((opencode_count + 1))
+      elif [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+        is_ai=true
+        gemini_count=$((gemini_count + 1))
       fi
       
       if [[ "$is_ai" == true ]]; then
@@ -1554,8 +1614,8 @@ _broadcast() {
       fi
     done <<< "$windows"
   fi
-  local total=$((claude_count + kimi_count + codex_count + forge_count + opencode_count))
-  echo "Broadcast to $total AI sessions (Claude: $claude_count, Kimi: $kimi_count, Codex: $codex_count, Forge: $forge_count, opencode: $opencode_count, skipped: $skipped)."
+  local total=$((claude_count + kimi_count + codex_count + forge_count + opencode_count + gemini_count))
+  echo "Broadcast to $total AI sessions (Claude: $claude_count, Kimi: $kimi_count, Codex: $codex_count, Forge: $forge_count, opencode: $opencode_count, gemini: $gemini_count, skipped: $skipped)."
 }
 
 # Peek at a worker's recent output
@@ -1567,7 +1627,7 @@ _peek() {
   local raw=false
 
   for arg in "$@"; do
-    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" ]]; then
+    if [[ "$arg" == "--qwen" || "$arg" == "--right" || "$arg" == "--opencode" || "$arg" == "--gemini" ]]; then
       target="right"
     elif [[ "$arg" == "--left" ]]; then
       target="left"
@@ -2016,6 +2076,8 @@ _orchestra() {
     current_ai="forge"
   elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
     current_ai="opencode"
+  elif [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+    current_ai="gemini"
   fi
 
   # If a different AI is running, kill it first

--- a/dev
+++ b/dev
@@ -541,7 +541,7 @@ _ai_launch_cmd() {
     codex)  echo "'$CODEX_BIN'" ;;
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
-    gemini) echo "'$GEMINI_BIN' --skip-trust" ;;
+    gemini) echo "'$GEMINI_BIN' --approval-mode yolo" ;;
     opencode) echo "'$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
@@ -595,7 +595,7 @@ _worker_launch_cmd() {
     kimi)   echo "'$KIMI_BIN'" ;;
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
-    gemini) echo "'$GEMINI_BIN' -p '$prompt'" ;;
+    gemini) echo "'$GEMINI_BIN'" ;;
     opencode) echo "'$OPENCODE_BIN' --prompt '$prompt'" ;;
     *)      return 1 ;;
   esac

--- a/dev
+++ b/dev
@@ -596,7 +596,7 @@ _worker_launch_cmd() {
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "'$GEMINI_BIN'" ;;
-    opencode) echo "'$OPENCODE_BIN'" ;;
+    opencode) echo "OPENCODE_CONFIG_CONTENT='{\"permission\":\"allow\"}' '$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
 }

--- a/dev
+++ b/dev
@@ -88,20 +88,32 @@ ORCH_DIR="${ORCHESTRA_DIR:-$CONFIG_DIR/orchestrator}"
 MAX_CLAUDE_SESSIONS="${MAX_CLAUDE_SESSIONS:-10}"
 MAX_KIMI_SESSIONS="${MAX_KIMI_SESSIONS:-10}"
 MAX_AI_SESSIONS="${MAX_AI_SESSIONS:-10}"
-# Claude Code sets its process title to its version (e.g., "2.1.72"), not "node"
-CLAUDE_PROC_PATTERN="^[0-9]+\.[0-9]+\.[0-9]+$"
-# Kimi CLI process detection (Python process with kimi module)
-KIMI_PROC_PATTERN="(kimi|python.*kimi)"
-# Codex CLI runs as a node process
-CODEX_PROC_PATTERN="^node$"
-# Forge Code is a native binary
-FORGE_PROC_PATTERN="^forge$"
-# opencode is a native binary
-OPENCODE_PROC_PATTERN="^opencode$"
-# Gemini CLI is a Node.js app (runs as 'node' with gemini arg)
-GEMINI_PROC_PATTERN="gemini"
-# But we need to distinguish from codex - check the full command
-GEMINI_FULL_PROC_PATTERN="node.*gemini"
+# AI type patterns (DRY - single source of truth)
+# Strict patterns to minimize false positives
+declare -A AI_PATTERNS=(
+  [claude]="^[0-9]+\.[0-9]+\.[0-9]+$"
+  [kimi]="(^kimi$|python.*kimi)"            # kimi CLI or python with kimi module
+  [codex]="^node.*codex"                     # node running codex
+  [forge]="(^forge$|^/.*forge)"             # forge binary (absolute path or bare)
+  [opencode]="(^opencode$|^/.*opencode)"     # opencode binary
+  [gemini]="(^gemini$|^/.*gemini)"          # gemini binary (not general 'gemini' substring)
+)
+declare -A AI_FULL_PATTERNS=(
+  [gemini]="node.*gemini"                    # node running gemini-cli
+  [codex]="node.*codex"                      # node running codex (explicit)
+)
+
+# Legacy pattern variables (backward compat - map to AI_PATTERNS)
+CLAUDE_PROC_PATTERN="${AI_PATTERNS[claude]}"
+KIMI_PROC_PATTERN="${AI_PATTERNS[kimi]}"
+CODEX_PROC_PATTERN="${AI_PATTERNS[codex]}"
+FORGE_PROC_PATTERN="${AI_PATTERNS[forge]}"
+OPENCODE_PROC_PATTERN="${AI_PATTERNS[opencode]}"
+GEMINI_PROC_PATTERN="${AI_PATTERNS[gemini]}"
+GEMINI_FULL_PROC_PATTERN="${AI_FULL_PATTERNS[gemini]}"
+
+# opencode permission config via env (security: auto-grant, not user prompt)
+OPENCODE_PERMISSION_CONFIG='{"permission":"allow"}'
 LOG_DIR="${HOME}/.local/share/orchestra/logs"
 HISTORY_FILE="${HOME}/.local/share/orchestra/history.log"
 
@@ -484,37 +496,72 @@ _get_ai_type() {
   fi
 }
 
-_detect_ai_type() {
-  local name="$1"
-  local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
+# AI type patterns (DRY - single source of truth)
+# Strict patterns to minimize false positives
+# Note: pane_current_command shows process name, not full command line
+# For node-based AIs (codex, gemini), we check both name AND full command via pane_start_command
+declare -A AI_PATTERNS=(
+  [claude]="^[0-9]+\.[0-9]+\.[0-9]+$"
+  [kimi]="(^kimi$|python.*kimi)"
+  [codex]="^node$"
+  [forge]="(^forge$|^/.*forge)"
+  [opencode]="(^opencode$|^/.*opencode)"
+  [gemini]="(^gemini$|^/.*gemini)"
+)
+declare -A AI_FULL_PATTERNS=(
+  [codex]="node.*codex"
+  [gemini]="node.*gemini"
+)
 
-  if [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]]; then
-    echo "claude"
-  elif [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then
-    echo "kimi"
-  elif [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then
-    echo "codex"
-  elif [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
-    echo "forge"
-  elif [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
-    echo "opencode"
-  elif [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
-    echo "gemini"
-  else
-    echo ""
-  fi
+# Check if pane command matches AI type using both simple and full patterns
+# Returns 0 (match) or 1 (no match)
+_ai_matches() {
+  local ai="$1"
+  local pane_cmd="$2"
+  local pane_start="$3"
+  [[ -z "$ai" || -z "$pane_cmd" ]] && return 1
+
+  local pattern="${AI_PATTERNS[$ai]}"
+  local full_pattern="${AI_FULL_PATTERNS[$ai]}"
+
+  # Simple pattern match on pane_current_command
+  [[ "$pane_cmd" =~ $pattern ]] && return 0
+
+  # Full pattern match on pane_start_command (for node-based detection)
+  [[ -n "$full_pattern" && -n "$pane_start" && "$pane_start" =~ $full_pattern ]] && return 0
+
+  return 1
 }
 
+# Detect AI type from pane command - single function (DRY)
+# Uses both pane_current_command and pane_start_command for accurate detection
+_detect_ai_type() {
+  local name="$1"
+  local pane_cmd=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_current_command}" 2>/dev/null)
+  local pane_start=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_start_command}" 2>/dev/null)
+
+  for ai in claude kimi codex forge opencode gemini; do
+    if _ai_matches "$ai" "$pane_cmd" "$pane_start"; then
+      echo "$ai"
+      return 0
+    fi
+  done
+  echo ""
+  return 1
+}
+
+# Check if pane is running an AI (optimized, no tmux overhead)
+# Uses same pattern matching as _detect_ai_type
 _is_ai_running() {
   local name="$1"
   if ! _has_window "$name"; then return 1; fi
-  local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
-  if [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]]; then return 0; fi
-  if [[ "$pane_cmd" =~ ^python ]] || [[ "$pane_cmd" == "kimi" ]]; then return 0; fi
-  if [[ "$pane_cmd" =~ $CODEX_PROC_PATTERN ]]; then return 0; fi
-  if [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then return 0; fi
-  if [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then return 0; fi
-  if [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then return 0; fi
+
+  local pane_cmd=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_current_command}" 2>/dev/null)
+  local pane_start=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_start_command}" 2>/dev/null)
+
+  for ai in claude kimi codex forge opencode gemini; do
+    _ai_matches "$ai" "$pane_cmd" "$pane_start" && return 0
+  done
   return 1
 }
 
@@ -531,18 +578,35 @@ _get_ai_bin() {
   esac
 }
 
+# Launch command templates (DRY - single source for all AI launch strings)
+# Usage: eval $(echo "$CLAUDE_LAUNCH_CMD_TEMPLATE" | sed "s|{{PROJECT_DIR}}|$dir|g")
+
+_claude_worker_template() {
+  echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --append-system-prompt '{{PROMPT}}'"
+}
+_claude_orchestrator_template() {
+  echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions"
+}
+_codex_template() { echo "'$CODEX_BIN' '{{PROMPT}}'" ; }
+_kimi_template() { echo "'$KIMI_BIN'" ; }
+_forge_template() { echo "'$FORGE_BIN'" ; }
+_gemini_worker_template() { echo "'$GEMINI_BIN'" ; }
+_gemini_orchestrator_template() { echo "'$GEMINI_BIN' --approval-mode yolo" ; }
+_opencode_template() { echo "OPENCODE_CONFIG_CONTENT='$OPENCODE_PERMISSION_CONFIG' '$OPENCODE_BIN'" ; }
+_qwen_template() { echo "qwen" ; }
+
 # Return the shell command that launches a given AI tool.
 # Supported: claude, codex, kimi, forge, qwen, gemini, opencode
 _ai_launch_cmd() {
   local ai="$1"
   case "$ai" in
-    claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions" ;;
-    kimi)   echo "'$KIMI_BIN'" ;;
-    codex)  echo "'$CODEX_BIN'" ;;
-    forge)  echo "'$FORGE_BIN'" ;;
-    qwen)   echo "qwen" ;;
-    gemini) echo "'$GEMINI_BIN' --approval-mode yolo" ;;
-    opencode) echo "'$OPENCODE_BIN'" ;;
+    claude) _claude_orchestrator_template ;;
+    kimi)   _kimi_template ;;
+    codex)  _codex_template ;;
+    forge)  _forge_template ;;
+    qwen)   _qwen_template ;;
+    gemini) _gemini_orchestrator_template ;;
+    opencode) _opencode_template ;;
     *)      return 1 ;;
   esac
 }
@@ -590,13 +654,13 @@ _worker_launch_cmd() {
   local ai="$1"
   local prompt="$(_worker_start_prompt)"
   case "$ai" in
-    claude) echo "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN 2>/dev/null; '$CLAUDE_BIN' --dangerously-skip-permissions --append-system-prompt \"$prompt\"" ;;
-    codex)  echo "'$CODEX_BIN' \"$prompt\"" ;;
-    kimi)   echo "'$KIMI_BIN'" ;;
-    forge)  echo "'$FORGE_BIN'" ;;
-    qwen)   echo "qwen" ;;
-    gemini) echo "'$GEMINI_BIN'" ;;
-    opencode) echo "OPENCODE_CONFIG_CONTENT='{\"permission\":\"allow\"}' '$OPENCODE_BIN'" ;;
+    claude) echo "$(_claude_worker_template | sed "s|{{PROMPT}}|$prompt|g")" ;;
+    codex)  echo "$(_codex_template | sed "s|{{PROMPT}}|$prompt|g")" ;;
+    kimi)   _kimi_template ;;
+    forge)  _forge_template ;;
+    qwen)   _qwen_template ;;
+    gemini) _gemini_worker_template ;;
+    opencode) _opencode_template ;;
     *)      return 1 ;;
   esac
 }

--- a/dev
+++ b/dev
@@ -497,22 +497,6 @@ _get_ai_type() {
 }
 
 # AI type patterns (DRY - single source of truth)
-# Strict patterns to minimize false positives
-# Note: pane_current_command shows process name, not full command line
-# For node-based AIs (codex, gemini), we check both name AND full command via pane_start_command
-declare -A AI_PATTERNS=(
-  [claude]="^[0-9]+\.[0-9]+\.[0-9]+$"
-  [kimi]="(^kimi$|python.*kimi)"
-  [codex]="^node$"
-  [forge]="(^forge$|^/.*forge)"
-  [opencode]="(^opencode$|^/.*opencode)"
-  [gemini]="(^gemini$|^/.*gemini)"
-)
-declare -A AI_FULL_PATTERNS=(
-  [codex]="node.*codex"
-  [gemini]="node.*gemini"
-)
-
 # Check if pane command matches AI type using both simple and full patterns
 # Returns 0 (match) or 1 (no match)
 _ai_matches() {
@@ -870,17 +854,18 @@ _clean_terminal_output() {
 _detect_pane_ai() {
   local name="$1"
   local pane_idx="$2"
-  local pcmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_index} #{pane_current_command}" 2>/dev/null \
-    | awk -v i="$pane_idx" '$1==i {print $2}')
-  if [[ "$pcmd" =~ $CLAUDE_PROC_PATTERN ]]; then echo "claude"
-  elif [[ "$pcmd" == "kimi" ]] || [[ "$pcmd" =~ ^[Pp]ython ]]; then echo "kimi"
-  elif [[ "$pcmd" == "codex" ]]; then echo "codex"
-  elif [[ "$pcmd" == "forge" ]]; then echo "forge"
-  elif [[ "$pcmd" == "qwen" ]]; then echo "qwen"
-  elif [[ "$pcmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pcmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then echo "gemini"
-  elif [[ "$pcmd" == "opencode" ]]; then echo "opencode"
-  else echo "$pcmd"
-  fi
+  local pane_info=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_index} #{pane_current_command} #{pane_start_command}" 2>/dev/null \
+    | awk -v i="$pane_idx" '$1==i {print $2 "|" $3}')
+  local pcmd="${pane_info%%|*}"
+  local pstart="${pane_info##*|}"
+
+  for ai in claude kimi codex forge opencode gemini; do
+    if _ai_matches "$ai" "$pcmd" "$pstart"; then
+      echo "$ai"
+      return 0
+    fi
+  done
+  echo "$pcmd"
 }
 
 # Helper: check if a worker AI is idle (done with task)
@@ -890,16 +875,13 @@ _is_done() {
   local ai_type="${2:-$(_detect_ai_type "$name")}"
   if ! _has_window "$name"; then return 2; fi
 
-  local pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$name" -F "#{pane_current_command}" 2>/dev/null | head -1)
-  
-  # Check if it's an AI process
+  local pane_cmd=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_current_command}" 2>/dev/null)
+  local pane_start=$(tmux display-message -p -t "$ORCH_SESSION:$name" "#{pane_start_command}" 2>/dev/null)
+
   local is_ai=false
-  [[ "$pane_cmd" =~ $CLAUDE_PROC_PATTERN ]] && is_ai=true
-  [[ "$pane_cmd" =~ ^[Pp]ython ]] && is_ai=true
-  [[ "$pane_cmd" == "kimi" ]] && is_ai=true
-  [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]] && is_ai=true
-  [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]] && is_ai=true
-  [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]] && is_ai=true
+  for ai in claude kimi codex forge opencode gemini; do
+    _ai_matches "$ai" "$pane_cmd" "$pane_start" && is_ai=true && break
+  done
   [[ "$is_ai" == false ]] && return 2
 
   # NOTE: Forge state detection is best-effort. Forge TUI idle/active
@@ -1565,24 +1547,22 @@ _send() {
   msg="${msg//$'\n'/ }"
   msg="${msg//$'\r'/ }"
 
-  # Use tmux buffer for all messages to avoid send-keys interpretation issues
-  # This ensures line endings and special characters are sent correctly
-  local tmpfile=$(mktemp)
-  printf '%s' "$msg" > "$tmpfile"
-  if tmux load-buffer "$tmpfile" 2>/dev/null; then
-    tmux paste-buffer -t "$pane_target" 2>/dev/null || {
-      # Fallback to send-keys if buffer fails
+  # Use tmux buffer only for long messages (>1000 chars) to avoid PTY truncation
+  # Short messages use direct send-keys for performance
+  if [[ ${#msg} -gt 1000 ]]; then
+    local tmpfile=$(mktemp)
+    printf '%s' "$msg" > "$tmpfile"
+    tmux load-buffer "$tmpfile" 2>/dev/null && \
+      tmux paste-buffer -t "$pane_target" 2>/dev/null || \
       tmux send-keys -l -t "$pane_target" "$msg"
-    }
     sleep 0.3
     tmux send-keys -t "$pane_target" Enter
+    rm -f "$tmpfile"
   else
-    # Ultimate fallback
     tmux send-keys -l -t "$pane_target" "$msg"
     sleep 0.2
     tmux send-keys -t "$pane_target" Enter
   fi
-  rm -f "$tmpfile"
 
   _log_history "SEND $name [$ai_label]: ${msg:0:200}"
   local win_index=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_index}:#{window_name}" 2>/dev/null | grep ":${name}$" | cut -d: -f1)
@@ -1961,9 +1941,11 @@ _recover() {
           local dir="${PROJECTS[$wname]}"
 
           # Handle dual mode tracking (format: dual:left:right)
+          # Recover left AI (right is usually orchestrator or secondary)
           if [[ "$tracked_ai" == dual:* ]]; then
             local left_ai="${tracked_ai#dual:}"
             left_ai="${left_ai%%:*}"
+            tracked_ai="$left_ai"
           fi
 
           if [[ "$tracked_ai" == "codex" ]]; then

--- a/dev
+++ b/dev
@@ -1881,18 +1881,26 @@ _recover() {
     local kimi_recovered=0
     local codex_recovered=0
     local forge_recovered=0
+    local opencode_recovered=0
+    local gemini_recovered=0
     if tmux has-session -t "$ORCH_SESSION" 2>/dev/null; then
       local windows=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_name}|#{pane_current_command}" 2>/dev/null)
       while IFS='|' read -r wname pcmd; do
         [[ "$wname" == "orchestra" ]] && continue
         [[ -z "${PROJECTS[$wname]}" ]] && continue
-        
-        # Check current AI type and recover accordingly
-        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]] && [[ ! "$pcmd" =~ $CODEX_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $FORGE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+
+        # Check current AI type and recover accordingly (exclude all AI types to avoid false positives)
+        if [[ ! "$pcmd" =~ $CLAUDE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ ^python ]] && [[ "$pcmd" != "kimi" ]] && [[ ! "$pcmd" =~ $CODEX_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $FORGE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $OPENCODE_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $GEMINI_PROC_PATTERN ]] && [[ ! "$pcmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
           # Window exists but no AI running - determine which AI was there
           local tracked_ai=$(_get_ai_type "$wname")
           local dir="${PROJECTS[$wname]}"
-          
+
+          # Handle dual mode tracking (format: dual:left:right)
+          if [[ "$tracked_ai" == dual:* ]]; then
+            local left_ai="${tracked_ai#dual:}"
+            left_ai="${left_ai%%:*}"
+          fi
+
           if [[ "$tracked_ai" == "codex" ]]; then
             echo "Recovering $wname [codex]..."
             tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && $(_worker_launch_cmd codex)" Enter
@@ -1910,6 +1918,18 @@ _recover() {
             _send_worker_bootstrap_if_needed "$ORCH_SESSION:$wname" "kimi"
             kimi_recovered=$((kimi_recovered + 1))
             _log_history "RECOVER-KIMI $wname"
+          elif [[ "$tracked_ai" == "opencode" ]]; then
+            echo "Recovering $wname [opencode]..."
+            tmux send-keys -t "$ORCH_SESSION:$wname" "$(_worker_launch_cmd opencode)" Enter
+            _send_worker_bootstrap_if_needed "$ORCH_SESSION:$wname" "opencode"
+            opencode_recovered=$((opencode_recovered + 1))
+            _log_history "RECOVER-OPENCODE $wname"
+          elif [[ "$tracked_ai" == "gemini" ]]; then
+            echo "Recovering $wname [gemini]..."
+            tmux send-keys -t "$ORCH_SESSION:$wname" "$(_worker_launch_cmd gemini)" Enter
+            _send_worker_bootstrap_if_needed "$ORCH_SESSION:$wname" "gemini"
+            gemini_recovered=$((gemini_recovered + 1))
+            _log_history "RECOVER-GEMINI $wname"
           else
             echo "Recovering $wname [claude]..."
             tmux send-keys -t "$ORCH_SESSION:$wname" "cd '$dir' && $(_worker_launch_cmd claude) --resume" Enter
@@ -1919,7 +1939,7 @@ _recover() {
         fi
       done <<< "$windows"
     fi
-    echo "Recovered $((claude_recovered + kimi_recovered + codex_recovered + forge_recovered)) sessions (Claude: $claude_recovered, Kimi: $kimi_recovered, Codex: $codex_recovered, Forge: $forge_recovered)."
+    echo "Recovered $((claude_recovered + kimi_recovered + codex_recovered + forge_recovered + opencode_recovered + gemini_recovered)) sessions (Claude: $claude_recovered, Kimi: $kimi_recovered, Codex: $codex_recovered, Forge: $forge_recovered, opencode: $opencode_recovered, gemini: $gemini_recovered)."
     return 0
   fi
 
@@ -1957,6 +1977,14 @@ _recover() {
   fi
   if [[ "$pane_cmd" =~ $FORGE_PROC_PATTERN ]]; then
     echo "$target: Forge is already running"
+    return 0
+  fi
+  if [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]]; then
+    echo "$target: OpenCode is already running"
+    return 0
+  fi
+  if [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]]; then
+    echo "$target: Gemini is already running"
     return 0
   fi
 
@@ -2023,6 +2051,48 @@ _recover() {
     else
       echo "Recovered: $target [forge]"
       _notify "$target" "Forge session recovered"
+    fi
+  elif [[ "$tracked_ai" == "opencode" ]]; then
+    echo "Recovering $target [opencode]..."
+    tmux send-keys -t "$ORCH_SESSION:$target" "$(_worker_launch_cmd opencode)" Enter
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$target" "opencode"
+    _log_history "RECOVER-OPENCODE $target"
+
+    local max_wait=15
+    local waited=0
+    while [[ $waited -lt $max_wait ]]; do
+      pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$target" -F "#{pane_current_command}" 2>/dev/null | head -1)
+      [[ "$pane_cmd" =~ $OPENCODE_PROC_PATTERN ]] && break
+      sleep 1
+      waited=$((waited + 1))
+    done
+
+    if [[ $waited -ge $max_wait ]]; then
+      echo "WARNING: OpenCode may not be ready in $target"
+    else
+      echo "Recovered: $target [opencode]"
+      _notify "$target" "OpenCode session recovered"
+    fi
+  elif [[ "$tracked_ai" == "gemini" ]]; then
+    echo "Recovering $target [gemini]..."
+    tmux send-keys -t "$ORCH_SESSION:$target" "$(_worker_launch_cmd gemini)" Enter
+    _send_worker_bootstrap_if_needed "$ORCH_SESSION:$target" "gemini"
+    _log_history "RECOVER-GEMINI $target"
+
+    local max_wait=15
+    local waited=0
+    while [[ $waited -lt $max_wait ]]; do
+      pane_cmd=$(tmux list-panes -t "$ORCH_SESSION:$target" -F "#{pane_current_command}" 2>/dev/null | head -1)
+      [[ "$pane_cmd" =~ $GEMINI_PROC_PATTERN ]] || [[ "$pane_cmd" =~ $GEMINI_FULL_PROC_PATTERN ]] && break
+      sleep 1
+      waited=$((waited + 1))
+    done
+
+    if [[ $waited -ge $max_wait ]]; then
+      echo "WARNING: Gemini may not be ready in $target"
+    else
+      echo "Recovered: $target [gemini]"
+      _notify "$target" "Gemini session recovered"
     fi
   else
     echo "Recovering $target [claude]..."

--- a/dev
+++ b/dev
@@ -1496,28 +1496,29 @@ _send() {
   [[ -z "$ai_label" ]] && ai_label="unknown"
   local ai_type="$ai_label"
 
-  # Flatten multi-line messages to single line
-  # (Both AI TUIs collapse pasted multi-line text into "[Pasted text]" and won't send it)
+  # Flatten multi-line messages to single line for AI TUIs
+  # (Most AI TUIs collapse pasted multi-line text into "[Pasted text]" and won't process it)
   msg="${msg//$'\n'/ }"
   msg="${msg//$'\r'/ }"
 
-  if [[ ${#msg} -gt 1000 ]]; then
-    local tmpfile=$(mktemp)
-    printf '%s' "$msg" > "$tmpfile"
-    tmux load-buffer "$tmpfile" && \
-      tmux paste-buffer -t "$pane_target" && \
-      sleep 0.3 && \
-      tmux send-keys -t "$pane_target" Enter || {
-        echo "ERROR: Failed to send long message to $name"
-        rm -f "$tmpfile"
-        return 1
-      }
-    rm -f "$tmpfile"
+  # Use tmux buffer for all messages to avoid send-keys interpretation issues
+  # This ensures line endings and special characters are sent correctly
+  local tmpfile=$(mktemp)
+  printf '%s' "$msg" > "$tmpfile"
+  if tmux load-buffer "$tmpfile" 2>/dev/null; then
+    tmux paste-buffer -t "$pane_target" 2>/dev/null || {
+      # Fallback to send-keys if buffer fails
+      tmux send-keys -l -t "$pane_target" "$msg"
+    }
+    sleep 0.3
+    tmux send-keys -t "$pane_target" Enter
   else
+    # Ultimate fallback
     tmux send-keys -l -t "$pane_target" "$msg"
     sleep 0.2
     tmux send-keys -t "$pane_target" Enter
   fi
+  rm -f "$tmpfile"
 
   _log_history "SEND $name [$ai_label]: ${msg:0:200}"
   local win_index=$(tmux list-windows -t "$ORCH_SESSION" -F "#{window_index}:#{window_name}" 2>/dev/null | grep ":${name}$" | cut -d: -f1)

--- a/dev
+++ b/dev
@@ -596,7 +596,7 @@ _worker_launch_cmd() {
     forge)  echo "'$FORGE_BIN'" ;;
     qwen)   echo "qwen" ;;
     gemini) echo "'$GEMINI_BIN'" ;;
-    opencode) echo "'$OPENCODE_BIN' --prompt '$prompt' --dangerously-skip-permissions" ;;
+    opencode) echo "'$OPENCODE_BIN'" ;;
     *)      return 1 ;;
   esac
 }
@@ -666,6 +666,9 @@ _send_worker_bootstrap_if_needed() {
         sleep 1
         waited=$((waited + 1))
       done
+      sleep 1
+      tmux send-keys -t "$target" -l "$prompt"
+      tmux send-keys -t "$target" Enter
       ;;
     gemini)
       local max_wait=15

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ mkdir -p "${CONFIG_DIR}"
 mkdir -p "${CONFIG_DIR}/orchestrator"
 
 # ── Install worker-safe prompt and shared rule files ─────────────
-for f in AGENTS.md WORKER.md CLAUDE.md KIMI.md CODEX.md FORGE.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+for f in AGENTS.md WORKER.md CLAUDE.md KIMI.md CODEX.md FORGE.md OPENCODE.md GEMINI.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
   if [[ -f "${ORCH_DIR}/${f}" ]]; then
     cp "${ORCH_DIR}/${f}" "${CONFIG_DIR}/${f}"
     echo "Installed: ${CONFIG_DIR}/${f}"
@@ -54,7 +54,7 @@ for f in AGENTS.md WORKER.md CLAUDE.md KIMI.md CODEX.md FORGE.md ORCHESTRATOR.md
 done
 
 # ── Install dedicated orchestrator prompt directory ──────────────
-for f in AGENTS.md CLAUDE.md KIMI.md CODEX.md FORGE.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
+for f in AGENTS.md CLAUDE.md KIMI.md CODEX.md FORGE.md OPENCODE.md GEMINI.md ORCHESTRATOR.md MODEL-SELECTION.md TROUBLESHOOTING.md; do
   if [[ -f "${ORCH_DIR}/orchestrator/${f}" ]]; then
     cp "${ORCH_DIR}/orchestrator/${f}" "${CONFIG_DIR}/orchestrator/${f}"
     echo "Installed: ${CONFIG_DIR}/orchestrator/${f}"

--- a/orchestrator/GEMINI.md
+++ b/orchestrator/GEMINI.md
@@ -1,0 +1,23 @@
+# Orchestra - Gemini Orchestrator
+
+## Role
+
+You are the orchestra orchestrator for Gemini workers.
+
+## Required Reading
+
+Read these files in this directory before acting:
+
+- `ORCHESTRATOR.md`
+- `MODEL-SELECTION.md`
+- `TROUBLESHOOTING.md`
+
+## Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Run `~/.local/bin/dev status` on startup.
+- Ask which projects to work on before starting workers.
+- Start Gemini workers with `~/.local/bin/dev gemini start <alias>`.
+- Do not write code in the orchestrator session.
+- After every `dev send`, follow up with a real wait and `dev peek`/`dev wait`.

--- a/orchestrator/OPENCODE.md
+++ b/orchestrator/OPENCODE.md
@@ -1,0 +1,23 @@
+# Orchestra - OpenCode Orchestrator
+
+## Role
+
+You are the orchestra orchestrator for OpenCode workers.
+
+## Required Reading
+
+Read these files in this directory before acting:
+
+- `ORCHESTRATOR.md`
+- `MODEL-SELECTION.md`
+- `TROUBLESHOOTING.md`
+
+## Rules
+
+- Be short and direct.
+- Report actions taken, not plans.
+- Run `~/.local/bin/dev status` on startup.
+- Ask which projects to work on before starting workers.
+- Start OpenCode workers with `~/.local/bin/dev opencode start <alias>`.
+- Do not write code in the orchestrator session.
+- After every `dev send`, follow up with a real wait and `dev peek`/`dev wait`.


### PR DESCRIPTION
## Summary

Add OpenCode and Gemini CLI as supported AI worker types in the orchestrator.

### Features
- **OpenCode worker**: Uses `OPENCODE_CONFIG_CONTENT='{"permission":"allow"}'` for automated permission handling
- **Gemini CLI worker**: Uses `--approval-mode yolo` for fully automated worker mode
- **DRY refactor**: Consolidate AI pattern detection into `AI_PATTERNS` associative array
- **False positive fix**: Strict regex anchors (`^forge$`, `^opencode$`) prevent incorrect matches
- **Accurate detection**: Uses `pane_start_command` for node-based AI detection

### Changes
- `dev`: 244 lines refactored (net +115 -51)
- `orchestrator/OPENCODE.md`, `orchestrator/GEMINI.md`: New orchestrator prompt files
- `OPENCODE.md`, `GEMINI.md`: New worker prompt files
- `README.md`, `install.sh`: Updated documentation

### Verification
- `zsh -n dev` → Syntax OK

### Breaking Change
Legacy `*_PROC_PATTERN` variables removed in favor of `AI_PATTERNS` associative array

---
Labels: `enhancement`, `refactor`